### PR TITLE
Renew deploy docs

### DIFF
--- a/docs/en/infrastructure_management/multi_tenant/functions/namespace-manage.mdx
+++ b/docs/en/infrastructure_management/multi_tenant/functions/namespace-manage.mdx
@@ -4,13 +4,13 @@ weight: 10
 
 # Namespace Management
 
-The tenants supported by AML are K8s namespaces, which need to be managed in **Namespace Management** before they can be used as tenants of AML.
+The tenants supported by Alauda AI are Kubernetes namespaces, which need to be managed in **Namespace Management** before they can be used as tenants of Alauda AI.
 
 The procedure to create a namespace and add users to this namespace are as follows:
 
-1. Log in to the ACP platform as an administrator
+1. Log into the Web Console as an administrator
 2. Create a namespace
-    1. Enter ACP **Project Management**
+    1. Switch to the **Projects** view
     2. Create or select an existing project, and then click to enter the current project details page.
     3. Click **Namespace** > **Namespace**
     4. Click **Create Namespace**
@@ -23,12 +23,12 @@ The procedure to create a namespace and add users to this namespace are as follo
         :::
 
 3. Assign namespace permissions to users
-    1. Enter ACP **Platform Management**
+    1. Switch to the **Administrator** view
     2. Select **User Role Management** > **User Management** from the navigation
     3. Create a new user or select the user to be added to this namespace
     4. Click the **Configure Role** tab and click the **Add Role** button
-    5. Configure AML-related roles for the user and select the previously created namespace
+    5. Configure Alauda AI-related roles for the user and select the previously created namespace
         - Editor: Users can create and delete workloads in the namespace and use resource quotas such as CPU and GPU to complete work
-        - Owner: Users have the permission to manage this AML namespace
+        - Owner: Users have the permission to manage this Alauda AI namespace
         - Viewer: Users can only view the resources of the namespace and cannot create or delete workloads
-4. Return to AML, click **Manage Namespace** in **Platform Management** > **Namespace Management**, and select the previously created namespace to complete the management
+4. Return to Alauda AI, click **Namespace Manage** in **Admin** > **Management Namespace**, and select the previously created namespace to complete the management

--- a/docs/en/installation/ai-cluster.mdx
+++ b/docs/en/installation/ai-cluster.mdx
@@ -146,6 +146,10 @@ Confirm that the **Alauda AI** tile shows one of the following states:
 
 Once Alauda AI Operator is installed, you can create an Alauda AI instance.
 
+:::info
+    During the deployment process of the Alauda AI Instance, the Alauda AI Model Serving operator and Instance will be automatically deployed, without requiring manual operation or configuration changes.
+:::
+
 ### Procedure
 
 In **Administrator** view:

--- a/docs/en/installation/ai-cluster.mdx
+++ b/docs/en/installation/ai-cluster.mdx
@@ -2,17 +2,21 @@
 weight: 30
 ---
 
-# Alauda AI Cluster Components
+# Install Alauda AI
 
 In the cluster where Alauda AI is to be used, the following two operators need to be deployed:
 
-1. Alauda AI
+1. Alauda AI Operator
 
-Alauda AI is a full-stack MLOps platform that establishes an efficient ecosystem centered around model, application, and dataset management. It provides a comprehensive MLOps/LLMOps/GenOps solution suite covering the entire workflow, including inference services, application deployment, data annotation, model fine-tuning, and service operations & maintenance. This enables you to effortlessly deploy inference services, precisely optimize models, and accurately achieve your business objectives.
+Alauda AI Operator is the main engine that powers Alauda AI products. It focuses on two core functions: model management and inference services, and provides a flexible framework that can be easily expanded.
 
-2. Alauda AI Model Serving
+2. Alauda AI Model Serving Operator
 
-Alauda AI Model Serving provides serverless model inference.
+Alauda AI Model Serving Operator provides serverless model inference.
+
+:::info
+    During the deployment process of the Alauda AI, the Alauda AI Model Serving Operator will be automatically deployed, without requiring manual operation or configuration changes.
+:::
 
 ## Downloading
 
@@ -146,10 +150,6 @@ Confirm that the **Alauda AI** tile shows one of the following states:
 
 Once Alauda AI Operator is installed, you can create an Alauda AI instance.
 
-:::info
-    During the deployment process of the Alauda AI Instance, the Alauda AI Model Serving operator and Instance will be automatically deployed, without requiring manual operation or configuration changes.
-:::
-
 ### Procedure
 
 In **Administrator** view:
@@ -227,6 +227,8 @@ Should returns `Ready`:
 NAME      READY   REASON
 default   True    Succeeded
 ```
+
+Now, the core capabilities of Alauda AI have been successfully deployed. If you want to quickly experience the product, please refer to the [Quick Start](../../overview/quick_start.mdx).
 
 ## Replace GitLab Service After Installation
 

--- a/docs/en/installation/ai-essentials.mdx
+++ b/docs/en/installation/ai-essentials.mdx
@@ -2,7 +2,7 @@
 weight: 20
 ---
 
-# Alauda AI Essentials
+# Install Alauda AI Essentials
 
 Alauda AI Essentials provides UI and RBAC resources for Alauda AI.
 
@@ -11,7 +11,8 @@ Alauda AI Essentials provides UI and RBAC resources for Alauda AI.
 :::info
 Alauda AI Essentials cluster plugin can be retrieved from Customer Portal.
 
-The package name is `aml-global-xxx.tgz`.
+1. Download the app named "AI".
+2. Unzip the downloaded file to obtain the `aml-global-xxx.tgz` packages.
 :::
 
 ## Uploading

--- a/docs/en/installation/index.mdx
+++ b/docs/en/installation/index.mdx
@@ -10,13 +10,14 @@ weight: 11
 - Additional resources for runtime serving are determined by the actual business scale: 10x7B-sized LLM inference instances at the same time, requires at least 10 GPUs and corresponding CPU, memory, disk storage, and object storage.
 - 200G free disk space for each worker node.
 
-## Prerequisites
+## Installing
 
-You must meet the following requirements before you can install Alauda AI on your ACP cluster:
+Installing Alauda AI involves the following high-level tasks:
 
-- **Cluster administrator access to your ACP cluster**
-- **MySQL 5.7 (or better)**
-- **Service Mesh with Istio 1.20 (or better)**
-- **Gitlab (Self-Hosted) v15 or better**
+1. Confirm and configure your cluster to meet all requirements. Refer to [Pre-installation Configuration](./pre-configuration.mdx).
+2. Install Alauda AI Essentials. Refer to [Install Alauda AI Essentials](./ai-essentials.mdx).
+3. Install Alauda AI. Refer to [Install Alauda AI](./ai-cluster.mdx).
+
+Then, the core capabilities of Alauda AI have been successfully deployed. If you want to quickly experience the product, please refer to the [Quick Start](../overview/quick_start.mdx).
 
 <Overview />

--- a/docs/en/installation/pre-configuration.mdx
+++ b/docs/en/installation/pre-configuration.mdx
@@ -4,30 +4,50 @@ weight: 5
 
 # Pre-installation Configuration
 
+## **Setting Default Storage Class**
+
+Before deploying Alauda AI, you need to set the default storage class for the cluster.
+
+1. Log in to the Web Console as an administrator.
+2. Switch to the **Administrator** view.
+3. Click **Storage** > **StorageClasses**.
+4. Click **Create StorageClass** to deploy a storage class, e.g., TopoLVM. If the desired storage class is already deployed, skip this step.
+5. Select the storage class to set as default,and click **Set Default**.
+
+## **Deploy Service Mesh**
+
+Since Alauda AI leverages Service Mesh capabilities for model inference services, Service Mesh must be deployed in the cluster before deploying Alauda AI. For detailed deployment procedures, refer to <ExternalSiteLink name="servicemesh" href="/install/create_service_mesh/index.mdx" children="Create Service Mesh" />.
+
+:::info
+
+After completing the **Prerequisites** on the **Create Service Mesh** page, proceed to the **Creating a Service Mesh** page and follow the on-screen instructions to finalize the deployment of the Service Mesh.
+
+:::
+
 ## **Preparing the GitLab Service**
 
-In Alauda AI, GitLab is the core component for **"Model Management"**. Before deploying Alauda AI, you **must prepare** a GitLab service.
+In Alauda AI, GitLab is the core component for **Model Management**. Before deploying Alauda AI, you **must prepare** a GitLab service.
 
 ### **Deployment Options**
 
-#### **1. Use the platform-provided plugin**
-
-Deploy a new GitLab service using the **'Alauda Build of GitLab'** plugin.
-For instructions, refer to: <ExternalSiteLink name="alauda-build-of-gitlab" href="/install/01_installation_guide.mdx" children="Deploy Alauda Build of GitLab" />.
-
-#### **2. Use your own GitLab service**
-
-Alternatively, you can use a **self-managed GitLab instance**, but it **must meet** the **GitLab service requirements**.
-
-#### **3. GitLab service requirements**
+#### **1. GitLab service requirements**
 
 Regardless of deployment method, all GitLab instances must satisfy:
 
 - **Version**: Must be **v15 or later**.
-- **Git LFS**: Must be **enabled**.
-- **Hosting**: Must be **self-hosted** (public cloud-hosted GitLab services are **not supported**).
 - **Protocol**: Must use **HTTPS**.
+- **Git LFS**: Must be **enabled**. For setup instructions, refer to <ExternalSiteLink name="alauda-build-of-gitlab" href="/howto/01_lfs.mdx" children="Managing Large Files with LFS" />.
+- **Hosting**: Must be **self-hosted** (public cloud-hosted GitLab services are **not supported**).
 - **Access Tokens**: **Disable expiration dates** for access tokens.
+
+#### **2. Use the platform-provided plugin**
+
+Deploy a new GitLab service using the **'Alauda Build of GitLab'** plugin.
+For instructions, refer to: <ExternalSiteLink name="alauda-build-of-gitlab" href="/install/01_installation_guide.mdx" children="Deploy Alauda Build of GitLab" />.
+
+#### **3. Use your own GitLab service**
+
+Alternatively, you can use a **self-managed GitLab instance**, but it **must meet** the **GitLab service requirements**.
 
 ### **GitLab Configuration**
 

--- a/sites.yaml
+++ b/sites.yaml
@@ -9,3 +9,10 @@
   version: v17.8
   repo: https://github.com/AlaudaDevops/gitlab-ce-operator
   image: devops/alauda-build-of-gitlab-docs
+- name: servicemesh
+  displayName:
+    en: Alauda Service Mesh
+    zh: Alauda Service Mesh
+  base: /servicemesh
+  version: "4.0"
+  repo: https://github.com/alauda/asm-docs


### PR DESCRIPTION
Renew deploy docs, include

1. Add default storage class
2. Add mesh deployment dependency
3. Optimize GitLab deployment sequence
4. Add LFS setup documentation
5. Add quick start guide link after deployment
6. Update multi-tenancy descriptions (view/product names)
