### PR TITLE
Add hami and pgpu sites

### DIFF
--- a/docs/en/infrastructure_management/device_management/hami.mdx
+++ b/docs/en/infrastructure_management/device_management/hami.mdx
@@ -1,0 +1,5 @@
+# About Alauda Build of Hami
+
+Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k8s-vGPU-scheduler, is an "all-in-one" chart designed to manage Heterogeneous AI Computing Devices in a k8s cluster. It can provide the ability to share Heterogeneous AI devices among tasks.
+
+<ExternalSite name="hami" />

--- a/docs/en/infrastructure_management/device_management/intro.mdx
+++ b/docs/en/infrastructure_management/device_management/intro.mdx
@@ -1,6 +1,0 @@
----
-title: Introduction
-weight: 10
----
-
-The prerequisite for using AI is to deploy the GPU plugin. I will not repeat the details here. Please refer to <ExternalSiteLink name="acp" href="/hardware_accelerator/configuration_management/functions/config_gpu.mdx" children="GPU config" />.

--- a/docs/en/infrastructure_management/device_management/pgpu.mdx
+++ b/docs/en/infrastructure_management/device_management/pgpu.mdx
@@ -1,0 +1,9 @@
+# About Alauda Build of NVIDIA GPU Device Plugin
+
+The NVIDIA device plugin for Kubernetes is a Daemonset that allows you to automatically:
+
+- Expose the number of GPUs on each nodes of your cluster
+- Keep track of the health of your GPUs
+- Run GPU enabled containers in your Kubernetes cluster.
+
+<ExternalSite name="pgpu" />

--- a/sites.yaml
+++ b/sites.yaml
@@ -16,3 +16,17 @@
   base: /servicemeshv1
   version: "4.0"
   repo: https://github.com/alauda/asm-docs
+- name: hami
+  displayName:
+    en: Alauda Build of Hami
+    zh: Alauda Build of Hami
+  base: /hami
+  version: "2.6"
+  repo: https://github.com/alauda/hami-docs
+- name: pgpu
+  displayName:
+    en: Alauda Build of NVIDIA GPU Device Plugin
+    zh: Alauda Build of NVIDIA GPU Device Plugin
+  base: /pgpu
+  version: "0.17"
+  repo: https://github.com/alauda/pgpu-doc


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added HAMi documentation introducing heterogeneous AI device management and sharing in Kubernetes, with a link to the dedicated site.
  - Added NVIDIA GPU Device Plugin (PGPU) documentation outlining capabilities and linking to its site.
  - Removed the Device Management Introduction page.
  - Updated documentation portal: removed the GitLab site; added public sites for HAMi and NVIDIA GPU Device Plugin; adjusted the Service Mesh entry to include its repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->