### PR TITLE
Update deployDocs for 1.4

### DIFF
--- a/docs/en/installation/index.mdx
+++ b/docs/en/installation/index.mdx
@@ -4,11 +4,19 @@ weight: 11
 
 # Install
 
-## Hardware requirements
+## Requirements
 
+### Hardware
 - At least two nodes with 16 cores and 32 GB of memory in total.
 - Additional resources for runtime serving are determined by the actual business scale: 10x7B-sized LLM inference instances at the same time, requires at least 10 GPUs and corresponding CPU, memory, disk storage, and object storage.
 - 200G free disk space for each worker node.
+
+### Software
+- CUDA Toolkit Version: 12.6 or higher.
+
+:::info
+    If your GPU does not support CUDA 12.6, you may still use lower versions of the CUDA Toolkit.However, after deploying Alauda AI, it is necessary to add a custom inference runtime that is adapted for older CUDA versions. This can be done by referring to [Extend LLM Inference Runtimes](../model_inference/inference_service/how_to/custom_inference_runtime.mdx),since the built-in vLLM inference runtime only supports CUDA 12.6 or later versions.
+:::
 
 ## Installing
 

--- a/docs/en/installation/pre-configuration.mdx
+++ b/docs/en/installation/pre-configuration.mdx
@@ -25,7 +25,7 @@ In Alauda AI, GitLab is the core component for **Model Management**. Before depl
 Regardless of deployment method, all GitLab instances must satisfy:
 
 - **Version**: Must be **v15 or later**.
-- **Protocol**: Must use **HTTPS**.
+- **Protocol**: Must use **HTTPS**. For setup instructions, refer to <ExternalSiteLink name="alauda-build-of-gitlab" href="/howto/03_gitlab_deploy.md#gitlab_https" children="Configure HTTPS" />.
 - **Git LFS**: Must be **enabled**. For setup instructions, refer to <ExternalSiteLink name="alauda-build-of-gitlab" href="/howto/01_lfs.mdx" children="Managing Large Files with LFS" />.
 - **Hosting**: Must be **self-hosted** (public cloud-hosted GitLab services are **not supported**).
 - **Access Tokens**: **Disable expiration dates** for access tokens.

--- a/docs/en/overview/quick_start.mdx
+++ b/docs/en/overview/quick_start.mdx
@@ -62,11 +62,9 @@ Include the created namespace in Alauda AI management:
 Upload the text classification model to the model repository:
 
 1. Enter Alauda AI, select **Business view** in the top navigation, and select the managed namespace from the previous step.
-2. Click **Model Repository** in the left navigation bar, click **Create Model Repository**, and enter the prepared model name, such as "gpt2".
-3. After creation, enter the **File Management** tab on the model details page.
-4. Click **Import Model File**, and drag or select the model files/subfolders to upload. If uploading a Large Language Model, the UI may freeze due to the large file size. It is recommended to use the git push command to push large model files to the model repository.
-5. Click the **Import** button and wait for the upload to complete.
-6. In the **File Management** tab, click **Update metadata** and select the correct "Task Type" and "Framework" according to the attributes of the large model.
+2. Click **Model Repository** in the left navigation bar, click **Create Model Repository**, and enter the prepared model name, such as "Meta-Llama-3-8B-Instruct".
+3. To complete model uploading, refer to the [Create Model Repository](../model_inference/model_management/functions/model_repository.mdx#create-model-repository).
+4. In the **File Management** tab, click **Update metadata** and select the correct "Task Type" and "Framework" according to the attributes of the large model.
    - Task Type: It is an attribute of the model itself and can be obtained by viewing the label on the model download details page. It is divided into "Text Generation", "Image Generation", etc.
    - Framework: It is also an attribute of the model itself and can be obtained by viewing the label on the model download details page. It is divided into "Transformers", "MLflow", etc. Most popular open-source Large Language Models are of the "Transformers" type.
 
@@ -75,16 +73,17 @@ Publish the model as an online inference service:
 
 1. On the model details page, click **Publish inference API** > **Custom publishing**.
 2. Configure service parameters:
-   - Name: gpt2-service
-   - Model: gpt2
+   - Name: meta-llama-3-8b-service
+   - Model: Meta-Llama-3-8B-Instruct
    - Version: Branch-main
-   - Inference Runtimes: Needs to be selected based on the cuda version installed in the GPU node. For example, if the cuda11 driver is installed, select "vllm-cuda11.8-x86". If cuda12 is installed, select "vllm-cuda12.1-x86".
-   - Resource Requests: 1CPU/4Gi Memory
-   - Resource Limits: 2CPU/6Gi Memory
-   - GPU Acceleration: GPU Manager
-     - GPU vcore: 30
-     - GPU vmemory: 32
-   - Storage: Mount existing PVC/created PVC or Temporary Storage/Capacity 10Gi
+   - Inference Runtimes: Needs to be selected based on the cuda version installed in the GPU node. For example,if cuda12.6 or later is installed, select "vllm-cuda12.6-x86".
+   - Resource Requests: 2CPU/20Gi Memory
+   - Resource Limits: 2CPU/20Gi Memory
+   - GPU Acceleration: HAMi NVIDIA
+     - gpu number: 1
+     - vgpu cores: 50
+     - GPU vmemory: 23552
+   - Storage: Mount existing PVC/Capacity 10Gi
    - Auto Scaling: Off
    - Number of instances: 1
 3. Click **Publish** and wait for the service to start.


### PR DESCRIPTION
1,Update quickstart,incloud use HAMi,demo model change to llama,upload model use command
2,Add cuda toolkid request
3,Add refer of gitlab https

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Installation: Consolidated Requirements section with separate Hardware and Software subsections. Added clearer hardware specs (minimum nodes, CPU/memory, disk) and guidance for runtime-serving capacity. Specified CUDA Toolkit 12.6+ with note on custom runtimes for lower versions; clarified built-in vLLM support.
  - Pre-configuration: Added inline HTTPS setup reference for GitLab requirements.
  - Quick Start: Updated example model/service to Meta-Llama-3-8B; linked to Create Model Repository guide; refreshed runtime to CUDA 12.6+, and revised CPU/memory, GPU, and storage parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->