### PR TITLE
update the URL of gitlab https

### DIFF
--- a/docs/en/installation/pre-configuration.mdx
+++ b/docs/en/installation/pre-configuration.mdx
@@ -25,7 +25,7 @@ In Alauda AI, GitLab is the core component for **Model Management**. Before depl
 Regardless of deployment method, all GitLab instances must satisfy:
 
 - **Version**: Must be **v15 or later**.
-- **Protocol**: Must use **HTTPS**. For setup instructions, refer to <ExternalSiteLink name="alauda-build-of-gitlab" href="/howto/03_gitlab_deploy.md#gitlab_https" children="Configure HTTPS" />.
+- **Protocol**: Must use **HTTPS**. For setup instructions, refer to <ExternalSiteLink name="alauda-build-of-gitlab" href="/install/03_gitlab_deploy.md#gitlab_https" children="Configure HTTPS" />.
 - **Git LFS**: Must be **enabled**. For setup instructions, refer to <ExternalSiteLink name="alauda-build-of-gitlab" href="/howto/01_lfs.mdx" children="Managing Large Files with LFS" />.
 - **Hosting**: Must be **self-hosted** (public cloud-hosted GitLab services are **not supported**).
 - **Access Tokens**: **Disable expiration dates** for access tokens.


### PR DESCRIPTION
update the URL of gitlab https

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitLab HTTPS configuration link in the installation pre-configuration guide to point to the correct location, ensuring smooth navigation to deployment instructions.
  * No other content changes; this fixes a broken/outdated reference without affecting functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->