### PR TITLE
upgrade servicemeshv1 version

### DIFF
--- a/sites.yaml
+++ b/sites.yaml
@@ -14,7 +14,7 @@
     en: Alauda Service Mesh v1
     zh: Alauda Service Mesh v1
   base: /servicemeshv1
-  version: "4.0"
+  version: "4.1"
   repo: https://github.com/alauda/asm-docs
 - name: hami
   displayName:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Deployments now reference Service Mesh v1 version 4.1 across supported sites.
- Chores
  - Updated configuration to use Service Mesh v1 version 4.1 (previously 4.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->