### PR TITLE
feat: isvc schelude by cuda version

### DIFF
--- a/.cspell/terms.txt
+++ b/.cspell/terms.txt
@@ -1,1 +1,2 @@
 hami
+CUDA

--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -28,9 +28,9 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
 
 #### Solution 1: Manual labeling
   1. On each GPU node, run the following command to retrieve the supported CUDA runtime version:
-    ```bash
-    nvidia-smi | sed -n 's/.*CUDA Version: \([0-9.]\+\).*/\1/p'
-    ```
+     ```bash
+     nvidia-smi | sed -n 's/.*CUDA Version: \([0-9.]\+\).*/\1/p'
+     ```
     For example, the output might be 12.4.
   2. On the control node, label the GPU node with the corresponding major and minor version:
     ```bash
@@ -61,24 +61,24 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
   2. Parse the ClusterServingRuntime label:
     If `cpaas.io/accelerator-type` is nvidia, further parse `cpaas.io/cuda-version` (e.g., 11.8).
   3. Add nodeAffinity field in the inference service, example:
-  ```yaml
-  apiVersion: serving.kserve.io/v1beta1
-  kind: InferenceService
-  spec:
-    predictor:
-      affinity:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - weight: 100
-              preference:
-              matchExpressions:
-              - key: nvidia.com/cuda.runtime.major
-                operator: In
-                values: ["11"]
-              - key: nvidia.com/cuda.runtime.minor
-                operator: Gt
-                values: ["7"] # Since the k8s operator only supports Gt, which means greater than but not equal to, we use the rt version minus one to meet the requirements.
-  ```
+      ```yaml
+      apiVersion: serving.kserve.io/v1beta1
+      kind: InferenceService
+      spec:
+        predictor:
+          affinity:
+            nodeAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - weight: 100
+                  preference:
+                  matchExpressions:
+                  - key: nvidia.com/cuda.runtime.major
+                    operator: In
+                    values: ["11"]
+                  - key: nvidia.com/cuda.runtime.minor
+                    operator: Gt
+                    values: ["7"] # Since the k8s operator only supports Gt, which means greater than but not equal to, we use the rt version minus one to meet the requirements.
+      ```
 
 </Steps>

--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -1,0 +1,82 @@
+---
+weight: 15
+i18n:
+title:
+en: Configure Accurately Scheduling Inference Services based on the CUDA version
+zh: 配置基于 CUDA 版本对推理服务进行精确调度
+---
+
+# Configure Accurately Scheduling Inference Services based on the CUDA version
+
+## Introduction
+
+In a Kubernetes cluster, inconsistencies in GPU models and CUDA driver versions across different GPU nodes lead to the following issues:
+
+1. Version mismatch: The CUDA runtime version used by applications may be incompatible with the CUDA driver version on certain nodes, resulting in failures or performance problems.
+
+2. Scheduling challenges: The native Kubernetes scheduler is unaware of CUDA version dependencies and cannot guarantee that applications are scheduled onto GPU nodes with compatible versions.
+
+3. High maintenance overhead: Manually managing the CUDA version dependencies between nodes and applications increases operational complexity.
+
+This document provides a step-by-step guide for configuring accurately scheduling inference services based on the CUDA runtime version and Nvidia Driver version.
+With these settings, you can resolve the CUDA Runtime and CUDA Driver version mismatch at the Kubernetes scheduling level to ensure that applications are scheduled to compatible GPU nodes.
+
+
+## Steps
+<Steps>
+### Adding cuda version in node labels
+
+#### Solution 1: Manual labeling
+  1. On each GPU node, run the following command to retrieve the supported CUDA runtime version:
+    ```bash
+    nvidia-smi | sed -n 's/.*CUDA Version: \([0-9.]\+\).*/\1/p'
+    ```
+    For example, the output might be 12.4.
+  2. On the master node, label the GPU node with the corresponding major and minor version:
+    ```bash
+    kubectl label node <node-name> \
+    nvidia.com/cuda.runtime.major=12 \
+    nvidia.com/cuda.runtime.minor=4
+  ```
+
+#### Solution 2: Using Node Feature Discovery (NFD) and NVIDIA GPU feature discovery(GFD)
+
+  :::info
+
+  `Node Feature Discovery` cluster plugin can be retrieved from Customer Portal.
+
+  Please contact Consumer Support for more information.
+
+  :::
+
+  By deploying the Node Feature Discovery(NFD) cluster plugin and turning on the GFD extension, GPU nodes will automatically be labeled with the cuda version.
+
+  :::tip
+  Solution 2 is suitable for scenarios where manual labeling of large-scale GPU clusters is difficult.
+  :::
+
+#### Configure Accurately Scheduling Inference Services based on the CUDA version
+  Starting from Alauda AI 1.5, the product will automatically schedule pod of inference services by the cuda version. For earlier versions, you can follow the following steps:
+  1. Determine which ClusterServingRuntime you need to select when creating an inference service.
+  2. Parse the ClusterServingRuntime label:
+    If cpaas.io/accelerator-type is nvidia, further parse cpaas.io/cuda-version (e.g., 11.8).
+  3. Add nodeAffinity field in the inference service, example:
+  ```yaml
+  apiVersion: serving.kserve.io/v1beta1
+  kind: InferenceService
+  spec:
+    predictor:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/cuda.runtime.major
+                operator: In
+                values: ["11"]
+              - key: nvidia.com/cuda.runtime.minor
+                operator: Gt
+                values: ["7"] # Since the k8s operator only supports Gt, which means greater than but not equal to, we use the rt version minus one to meet the requirements.
+  ```
+
+</Steps>

--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -59,7 +59,7 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
   Starting from Alauda AI 1.5, the product will automatically schedule pod of inference services by the cuda version. For earlier versions, you can follow the following steps:
   1. Determine which ClusterServingRuntime you need to select when creating an inference service.
   2. Parse the ClusterServingRuntime label:
-    If cpaas.io/accelerator-type is nvidia, further parse cpaas.io/cuda-version (e.g., 11.8).
+    If `cpaas.io/accelerator-type` is nvidia, further parse `cpaas.io/cuda-version` (e.g., 11.8).
   3. Add nodeAffinity field in the inference service, example:
   ```yaml
   apiVersion: serving.kserve.io/v1beta1

--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -70,7 +70,9 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
+            - weight: 100
+              preference:
+              matchExpressions:
               - key: nvidia.com/cuda.runtime.major
                 operator: In
                 values: ["11"]

--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -24,7 +24,7 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
 
 ## Steps
 <Steps>
-### Adding cuda version in node labels
+### Adding CUDA version in node labels
 
 #### Solution 1: Manual labeling
   1. On each GPU node, run the following command to retrieve the supported CUDA runtime version:
@@ -32,7 +32,7 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
     nvidia-smi | sed -n 's/.*CUDA Version: \([0-9.]\+\).*/\1/p'
     ```
     For example, the output might be 12.4.
-  2. On the master node, label the GPU node with the corresponding major and minor version:
+  2. On the control node, label the GPU node with the corresponding major and minor version:
     ```bash
     kubectl label node <node-name> \
     nvidia.com/cuda.runtime.major=12 \
@@ -49,14 +49,14 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
 
   :::
 
-  By deploying the Node Feature Discovery(NFD) cluster plugin and turning on the GFD extension, GPU nodes will automatically be labeled with the cuda version.
+  By deploying the Node Feature Discovery(NFD) cluster plugin and turning on the GFD extension, GPU nodes will automatically be labeled with the CUDA version.
 
   :::tip
   Solution 2 is suitable for scenarios where manual labeling of large-scale GPU clusters is difficult.
   :::
 
 #### Configure Accurately Scheduling Inference Services based on the CUDA version
-  Starting from Alauda AI 1.5, the product will automatically schedule pod of inference services by the cuda version. For earlier versions, you can follow the following steps:
+  Starting from Alauda AI 1.5, the product will automatically schedule pod of inference services by the CUDA version. For earlier versions, you can follow the following steps:
   1. Determine which ClusterServingRuntime you need to select when creating an inference service.
   2. Parse the ClusterServingRuntime label:
     If `cpaas.io/accelerator-type` is nvidia, further parse `cpaas.io/cuda-version` (e.g., 11.8).

--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -68,7 +68,7 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
     predictor:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: nvidia.com/cuda.runtime.major


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a bilingual (English/Chinese) how-to for accurately scheduling inference services by CUDA runtime and NVIDIA driver versions.
  * Explains CUDA/runtime mismatches, scheduling challenges, and maintenance implications.
  * Describes manual CUDA major/minor node labeling, optional discovery via NFD/GFD, CLI labeling examples, and parsing of runtime labels for compatibility.
  * Includes a practical nodeAffinity example and guidance for different platform versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->