### PR TITLE
fix: preferredDuringSchedulingIgnoredDuringExecution

### DIFF
--- a/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
+++ b/docs/en/model_inference/inference_service/how_to/accurately_schedule.mdx
@@ -69,9 +69,8 @@ With these settings, you can resolve the CUDA Runtime and CUDA Driver version mi
           affinity:
             nodeAffinity:
               preferredDuringSchedulingIgnoredDuringExecution:
-                nodeSelectorTerms:
-                - weight: 100
-                  preference:
+              - weight: 100
+                preference:
                   matchExpressions:
                   - key: nvidia.com/cuda.runtime.major
                     operator: In


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the InferenceService scheduling example to use a simplified, correct Kubernetes node affinity structure.
  * Clarified the placement of weight and preference fields under preferredDuringSchedulingIgnoredDuringExecution for easier understanding.
  * Streamlined the YAML snippet to be copy-paste ready, reducing confusion when configuring scheduling preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->