### PR TITLE
fix: indentation

### DIFF
--- a/docs/en/workbench/how_to/create_workspace_kind.mdx
+++ b/docs/en/workbench/how_to/create_workspace_kind.mdx
@@ -21,21 +21,21 @@ Create a file workbench-sa-with-rolebinding.yaml with following lines, and run k
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-name: workbench-editor
-namespace: NAMESPACE_NAME # [!code callout]
+  name: workbench-editor
+  namespace: NAMESPACE_NAME # [!code callout]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-name: workbench-sa-binding
+  name: workbench-sa-binding
 subjects:
 - kind: ServiceAccount
-name: workbench-editor
-namespace: NAMESPACE_NAME # [!code callout]
+  name: workbench-editor
+  namespace: NAMESPACE_NAME # [!code callout]
 roleRef:
-kind: ClusterRole
-name: aml-namespace-editor
-apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aml-namespace-editor
+  apiGroup: rbac.authorization.k8s.io
 ```
 <Callouts>
   1. NAMESPACE_NAME should be same with the namespace of workbench created.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized YAML indentation in the Workbench “Create workspace kind” guide, using two-space indentation for ServiceAccount and ClusterRoleBinding examples.
  * Aligned metadata and roleRef field formatting to match Kubernetes conventions.
  * Improves readability and reduces risk of copy/paste validation errors when applying examples.
  * No behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->