### PR TITLE
add gpu dashboard note

### DIFF
--- a/docs/en/monitoring_ops/overview/intro.mdx
+++ b/docs/en/monitoring_ops/overview/intro.mdx
@@ -12,4 +12,4 @@ This module focuses on two key operational aspects:
 - **Logging**: Real-time streaming of inference service replica pod logs
 - **Monitor**: Multi-dimensional performance dashboards covering infrastructure, GPU resources, and API traffic
 
-Note: GPU dashboards of Hami is only supported in AML version 1.4 and later.
+Note: GPU dashboards of Hami are only supported in AML version 1.4 and later.

--- a/docs/en/monitoring_ops/overview/intro.mdx
+++ b/docs/en/monitoring_ops/overview/intro.mdx
@@ -11,3 +11,5 @@ Monitoring & Ops is a core module of the Alauda AI platform designed specificall
 This module focuses on two key operational aspects:
 - **Logging**: Real-time streaming of inference service replica pod logs
 - **Monitor**: Multi-dimensional performance dashboards covering infrastructure, GPU resources, and API traffic
+
+Note: GPU dashboards of Hami is only supported in AML version 1.4 and later.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a clarification to the Monitoring & Ops introduction noting that GPU dashboards are supported starting with AML version 1.4, so users running earlier AML versions should not expect GPU dashboard availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->