### PR TITLE
Add volcano vgpu note

### DIFF
--- a/docs/en/infrastructure_management/device_management/hami.mdx
+++ b/docs/en/infrastructure_management/device_management/hami.mdx
@@ -2,7 +2,9 @@
 
 Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k8s-vGPU-scheduler, is an "all-in-one" chart designed to manage Heterogeneous AI Computing Devices in a k8s cluster. It can provide the ability to share Heterogeneous AI devices among tasks.
 
-Note: You DON'T need to install HAMi when using volcano-vgpu for Fine-tuning or Pre-training jobs, only use
+You DON'T need to install HAMi when using volcano-vgpu for Fine-tuning or Pre-training jobs, only use
 Volcano vGPU device-plugin is good enough. It can provide device-sharing mechanism for NVIDIA devices managed by Volcano.
+
+For Volcano vGPU device-plugin installation instructions, please refer to the hami online documentation.
 
 <ExternalSite name="hami" />

--- a/docs/en/infrastructure_management/device_management/hami.mdx
+++ b/docs/en/infrastructure_management/device_management/hami.mdx
@@ -5,6 +5,6 @@ Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k
 You DON'T need to install HAMi when using volcano-vgpu for Fine-tuning or Pre-training jobs, only use
 Volcano vGPU device-plugin is good enough. It can provide device-sharing mechanism for NVIDIA devices managed by Volcano.
 
-For Volcano vGPU device-plugin installation instructions, please refer to the hami online documentation.
+For Volcano vGPU device-plugin installation instructions, please refer to the HAMi online documentation.
 
 <ExternalSite name="hami" />

--- a/docs/en/infrastructure_management/device_management/hami.mdx
+++ b/docs/en/infrastructure_management/device_management/hami.mdx
@@ -2,4 +2,7 @@
 
 Heterogeneous AI Computing Virtualization Middleware (HAMi), formerly known as k8s-vGPU-scheduler, is an "all-in-one" chart designed to manage Heterogeneous AI Computing Devices in a k8s cluster. It can provide the ability to share Heterogeneous AI devices among tasks.
 
+Note: You DON'T need to install HAMi when using volcano-vgpu for Fine-tuning or Pre-training jobs, only use
+Volcano vGPU device-plugin is good enough. It can provide device-sharing mechanism for NVIDIA devices managed by Volcano.
+
 <ExternalSite name="hami" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that HAMi is optional when using the Volcano vGPU device-plugin for Fine-tuning and Pre-training jobs.
  * Noted that the Volcano vGPU device-plugin provides NVIDIA device-sharing and can handle device management without HAMi.
  * Added guidance pointing readers to the HAMi online documentation for Volcano vGPU device-plugin installation instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->