### PR TITLE
fix git lfs version info

### DIFF
--- a/docs/en/model_inference/model_management/how_to/upload_models_using_notebook.mdx
+++ b/docs/en/model_inference/model_management/how_to/upload_models_using_notebook.mdx
@@ -53,7 +53,13 @@ After the model repository is created, you can find the model's "Repository Addr
 
 ## Uploading the model
 :::info
-    Using an earlier version of the `git` command line tool may cause the command line push method to fail. You need to use at least git version >= 2.2.
+    To guarantee stable upload/download of large-model files via Git LFS, ensure that both Git and Git LFS are updated to the latest official releases. Older versions can trigger LFS batch-API failures or HTTP-level exceptions, particularly on Windows systems that ship with outdated builds.
+    
+    _Download locations_:
+      - _Git: https://git-scm.com/downloads_
+      - _Git LFS: https://github.com/git-lfs/git-lfs/releases_
+
+    Reference versions (validated): Git `2.43.0` with Git LFS `3.6.1`
 :::
 > **Note:** Before beginning, ensure Git and Git LFS are installed in your Notebook environment: `git lfs install && git lfs version`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for uploading large models via Git LFS with best practices
  * Added explicit download locations for Git and Git LFS
  * Included validated version information (Git 2.43.0, Git LFS 3.6.1)
  * Expanded troubleshooting details for potential compatibility issues, particularly on Windows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->