### PR TITLE
chore: add menu docs AI-22956

### DIFF
--- a/docs/en/installation/tools.mdx
+++ b/docs/en/installation/tools.mdx
@@ -1,0 +1,75 @@
+---
+weight: 90
+---
+
+# Tools Menu Configuration
+
+This document describes how to add custom tool links to the **Tools** section in the left navigation, for example integrating **MLflow**.
+
+Starting with AML 1.3, the Tools menu is no longer maintained by manually editing `kube-public/centraldashboard-config`. Instead, an **auto-discovery mechanism** is used: the system scans all `ConfigMap` resources labeled with
+`aml.cpaas.io/centralMenuItem: "true"` and automatically merges them to generate the Tools menu configuration.
+
+:::warning
+Do not manually edit `kube-public/centraldashboard-config`. Any manual changes will be reverted during upgrades or restarts.
+:::
+
+## Add a Tools Menu Item
+
+You can add a new entry to the Tools menu by creating a `ConfigMap` that follows the required format.
+
+Example (MLflow):
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aml-mlflow-menu-config
+  namespace: kubeflow
+  labels:
+    aml.cpaas.io/centralMenuItem: "true"
+data:
+  menu: |-
+    - link: "https://192.168.128.11/clusters/g1-c1-x86/mlflow/"
+      parentUid: advanced
+      title: MLFlow
+      titleI18N:
+        en: MLFlow
+      tags: [kubeflow]
+      order: 200040
+```
+
+### Field Description
+
+- `link`: The URL to open when the menu item is clicked
+- `parentUid`: Must be set to `advanced`, which mounts the item under the **Tools** menu
+- `title / titleI18N`: Display name of the menu item, with internationalization support
+- `tags`: Indicates the features or capabilities required for this menu item to be shown in the Tools menu.
+- `order`: Menu ordering value; smaller numbers appear earlier
+
+## Result
+
+- After the ConfigMap is created, its content is automatically merged into the `data` section of `centraldashboard-config`, for example:
+
+    ```json
+    {
+      "type": "item",
+      "link": "",
+      "i18nKey": "tool",
+      "text": "Tools",
+      "en": "Tools",
+      "icon": "advanced",
+      "children": [
+        {
+          "type": "item",
+          "link": "https://192.168.128.11/clusters/g1-c1-x86/mlflow/",
+          "i18nKey": "",
+          "text": "MLFlow",
+          "en": "MLFlow",
+          "icon": ""
+        }
+      ]
+    }
+    ```
+- A corresponding menu item will appear under **Tools** in the left navigation
+- An arrow icon will be displayed on the right side of the menu item, indicating an external page
+- Clicking the menu item opens the URL specified in the `link` field in a new page

--- a/docs/en/installation/tools.mdx
+++ b/docs/en/installation/tools.mdx
@@ -4,7 +4,7 @@ weight: 90
 
 # Tools Menu Configuration
 
-This document describes how to add custom tool links to the **Tools** section in the left navigation, for example integrating **MLflow**.
+This document describes how to add custom tool links to the **Tools** section in the left navigation, for example integrating **MLFlow**.
 
 Starting with AML 1.3, the Tools menu is no longer maintained by manually editing `kube-public/centraldashboard-config`. Instead, an **auto-discovery mechanism** is used: the system scans all `ConfigMap` resources labeled with
 `aml.cpaas.io/centralMenuItem: "true"` and automatically merges them to generate the Tools menu configuration.
@@ -17,7 +17,7 @@ Do not manually edit `kube-public/centraldashboard-config`. Any manual changes w
 
 You can add a new entry to the Tools menu by creating a `ConfigMap` that follows the required format.
 
-Example (MLflow):
+Example (MLFlow):
 
 ```yaml
 apiVersion: v1
@@ -43,32 +43,145 @@ data:
 - `link`: The URL to open when the menu item is clicked
 - `parentUid`: Must be set to `advanced`, which mounts the item under the **Tools** menu
 - `title / titleI18N`: Display name of the menu item, with internationalization support
-- `tags`: Indicates the features or capabilities required for this menu item to be shown in the Tools menu.
+- `tags`: When installing Alauda AI, the system aggregates multiple `ConfigMaps` into a single `ConfigMap`. During this aggregation process, the system automatically adds an `aml-feature-tags` field to the merged configuration. By default, this field contains built-in tags such as `addon`, `core`, `datasets`, `pretrain`, `tune-models`, and `workbench`.
+
+  In the example above, if a menu item defines `tags` as `kubeflow`, then `aml-feature-tags` will also include this `kubeflow` entry.
+  The left navigation aggregation mechanism uses a **whitelist** design. For example, after running the following command, only navigation items whose `tags` contain `kubeflow` will be displayed on the page:
+  ```bash
+  kubectl annotate configmap aml-centraldashboard-config -n kube-public aml.cpaas.io/centralTagsFilter="kubeflow" --overwrite
+  ```
+  All other tags that do not match `kubeflow` will be evaluated as `false` during the filtering process and therefore excluded from the navigation.
+
 - `order`: Menu ordering value; smaller numbers appear earlier
 
 ## Result
 
 - After the ConfigMap is created, its content is automatically merged into the `data` section of `centraldashboard-config`, for example:
 
-    ```json
-    {
-      "type": "item",
-      "link": "",
-      "i18nKey": "tool",
-      "text": "Tools",
-      "en": "Tools",
-      "icon": "advanced",
-      "children": [
+    ```yaml
+    apiVersion: v1
+    data:
+      aml-feature-tags: |-
         {
-          "type": "item",
-          "link": "https://192.168.128.11/clusters/g1-c1-x86/mlflow/",
-          "i18nKey": "",
-          "text": "MLFlow",
-          "en": "MLFlow",
-          "icon": ""
+          "addon": true,
+          "core": true,
+          "datasets": true,
+          "kubeflow": true,
+          "pretrain": true,
+          "tune-models": true,
+          "workbench": true
         }
-      ]
-    }
+      links: |-
+        {
+          "menuLinks": [
+            {
+              "type": "item",
+              "link": "/model-repo/model",
+              "i18nKey": "nav_model_repo",
+              "text": "模型仓库",
+              "en": "Model Repository",
+              "icon": "model-repo"
+            },
+            {
+              "type": "item",
+              "link": "/model-repo/service-manage",
+              "i18nKey": "nav_infer_svc",
+              "text": "推理服务",
+              "en": "Inference Service",
+              "icon": "service-manage"
+            },
+            {
+              "type": "item",
+              "link": "workbench",
+              "i18nKey": "workbench",
+              "text": "Workbench",
+              "en": "Workbench",
+              "icon": "sitemap"
+            },
+            {
+              "type": "item",
+              "link": "",
+              "i18nKey": "nav_observe",
+              "text": "可观测",
+              "en": "Observe",
+              "icon": "observe",
+              "children": [
+                {
+                  "type": "item",
+                  "link": "monitor",
+                  "i18nKey": "nav_monitor",
+                  "text": "监控面板",
+                  "en": "Monitor",
+                  "icon": ""
+                }
+              ]
+            },
+            {
+              "type": "item",
+              "link": "/model-repo/dataset",
+              "i18nKey": "nav_dataset",
+              "text": "数据集",
+              "en": "Dataset",
+              "icon": "data-set"
+            },
+            {
+              "type": "item",
+              "link": "",
+              "i18nKey": "nav_model_optimization",
+              "text": "模型优化",
+              "en": "Model Optimization",
+              "icon": "model-repo",
+              "children": [
+                {
+                  "type": "item",
+                  "link": "/model-repo/training",
+                  "i18nKey": "nav_pre_train",
+                  "text": "预训练",
+                  "en": "PreTraining",
+                  "icon": ""
+                },
+                {
+                  "type": "item",
+                  "link": "/model-repo/task-template",
+                  "i18nKey": "nav_task_temp",
+                  "text": "任务模板",
+                  "en": "Task Template",
+                  "icon": ""
+                },
+                {
+                  "type": "item",
+                  "link": "/model-repo/fine-tuning",
+                  "i18nKey": "nav_fine_tuning",
+                  "text": "模型微调",
+                  "en": "Fine-Tuning",
+                  "icon": ""
+                }
+              ]
+            },
+            {
+              "type": "item",
+              "link": "",
+              "i18nKey": "tool",
+              "text": "工具",
+              "en": "Tools",
+              "icon": "advanced",
+              "children": [
+                {
+                  "type": "item",
+                  "link": "https://192.168.128.11/clusters/g1-c1-x86/mlflow/",
+                  "i18nKey": "",
+                  "text": "MLFlow",
+                  "en": "MLFlow",
+                  "icon": ""
+                }
+              ]
+            }
+          ]
+        }
+    kind: ConfigMap
+    metadata:
+      name: centraldashboard-config
+      namespace: kube-public
     ```
 - A corresponding menu item will appear under **Tools** in the left navigation
 - An arrow icon will be displayed on the right side of the menu item, indicating an external page


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for Tools Menu configuration in AML 1.3+. Covers auto-discovery of Tools menu items via specially labeled Kubernetes ConfigMaps, step‑by‑step instructions to add custom items (MLflow example), required fields (link, parentUid, title/titleI18N, tags, order), how merged menu data appears, UI behavior for external links, and tag-based filtering/visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->