### PR TITLE
fix: add missing heading anchors for doom-lint

### DIFF
--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -161,7 +161,7 @@ ingress:
         - <dify.example.com>
 ```
 
-### Storage (S3 and PVC)
+### Storage (S3 and PVC) \{#storage-s3-and-pvc}
 
 **PVC (default):** API and plugin daemon each use a PVC when enabled. Override storage class and size as needed.
 

--- a/docs/en/installation/ai-cluster.mdx
+++ b/docs/en/installation/ai-cluster.mdx
@@ -16,7 +16,7 @@ If your use case requires `Serverless` functionality, which enables advanced fea
     [Recommended deployment option](https://kserve.github.io/website/docs/admin-guide/overview#generative-inference): For generative inference workloads, the Raw Kubernetes Deployment approach is recommended as it provides the most control over resource allocation and scaling.
 :::
 
-## Downloading
+## Downloading \{#downloading}
 
 **Operator Components**:
 
@@ -36,7 +36,7 @@ If your use case requires `Serverless` functionality, which enables advanced fea
 You can download the app named 'Alauda AI' and 'Knative Operator' from the Marketplace on the Customer Portal website.
 :::
 
-## Uploading
+## Uploading \{#uploading}
 
 We need to upload both `Alauda AI` and `Knative Operator` to the cluster where Alauda AI is to be used.
 

--- a/docs/en/label_studio/install.mdx
+++ b/docs/en/label_studio/install.mdx
@@ -185,7 +185,7 @@ redirectURIs:
 
 ### 4. Configure User Management
 
-#### 4.1 Disable User Registration
+#### 4.1 Disable User Registration \{#41-disable-user-registration}
 
 User registration can be disabled by setting the following fields:
 

--- a/docs/en/llama_stack/quickstart.mdx
+++ b/docs/en/llama_stack/quickstart.mdx
@@ -34,7 +34,7 @@ The notebook demonstrates:
 
 ## FAQ
 
-### How to prepare Python 3.12 in Notebook
+### How to prepare Python 3.12 in Notebook \{#how-to-prepare-python-312-in-notebook}
 
 1. Download the pre-compiled Python installation package:
 

--- a/docs/en/model_inference/model_management/functions/model_repository.mdx
+++ b/docs/en/model_inference/model_management/functions/model_repository.mdx
@@ -64,6 +64,6 @@ The core definition of the model repository feature is to provide a Git-based ve
     - Misconfigured `README.md` metadata may block inference deployment.
 
 
-## Create Model and Upload Model Files
+## Create Model and Upload Model Files \{#create-model-repository}
 
 Refer to [Upload Models Using Notebook](../how_to/upload_models_using_notebook.mdx) for detailed steps on uploading model files to the model repository.


### PR DESCRIPTION
## Summary

- Add explicit custom IDs (`\{#id}`) to headings referenced by anchor links
- Fix 6 `doom-lint:no-unmatched-anchor` errors across 5 documentation files

## Changes

| File | Heading | Anchor ID |
|------|---------|-----------|
| `docs/en/dify/install.mdx` | Storage (S3 and PVC) | `storage-s3-and-pvc` |
| `docs/en/label_studio/install.mdx` | 4.1 Disable User Registration | `41-disable-user-registration` |
| `docs/en/llama_stack/quickstart.mdx` | How to prepare Python 3.12 in Notebook | `how-to-prepare-python-312-in-notebook` |
| `docs/en/model_inference/model_management/functions/model_repository.mdx` | Create Model and Upload Model Files | `create-model-repository` |
| `docs/en/installation/ai-cluster.mdx` | Downloading | `downloading` |
| `docs/en/installation/ai-cluster.mdx` | Uploading | `uploading` |

## Test plan

- [x] Run `doom lint` - 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)