### PR TITLE
docs: add Workbench Istio prerequisite

### DIFF
--- a/docs/en/installation/workbench.mdx
+++ b/docs/en/installation/workbench.mdx
@@ -4,6 +4,10 @@ weight: 15
 
 # Install Workbench
 
+## Prerequisites
+
+Before installing Workbench, make sure ASM (Istio) is deployed in the business cluster where Workbench will run. Workbench creates an Istio `EnvoyFilter` for Elyra and Kubeflow Pipelines run URL redirection, so the Istio CRDs must exist before the Workbench cluster plugin is installed.
+
 ## Installing Alauda AI Workbench Cluster Plugin
 
 ### Procedure
@@ -24,5 +28,4 @@ Access the feature gates at `{platform-access-address}/console-platform/feature-
 
 1. Find the gate list with the display name of your target which is `ai-workbench`.
 2. Turn On the switch button of it.
-
 


### PR DESCRIPTION
## Summary
- Cherry-pick the Workbench ASM/Istio prerequisite docs update from the release-2.4 fix.
- Explain that the Workbench plugin creates an Istio EnvoyFilter for Elyra/KFP run URL redirection.

## Related
- release-2.4 PR: https://github.com/alauda/aml-docs/pull/229

## Validation
- Cherry-pick completed without conflicts.
- git show --check passed for the cherry-picked commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Prerequisites section to Workbench installation guide, clarifying that ASM (Istio) must be deployed in the business cluster before installing the Workbench cluster plugin.
  * Simplified Feature Gate Configuration procedure for enabling the ai-workbench feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/aml-docs/pull/230)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->