### PR TITLE
Update AI 2.5 supported configurations

### DIFF
--- a/docs/en/learn/supported-configurations-for-2.x.md
+++ b/docs/en/learn/supported-configurations-for-2.x.md
@@ -8,31 +8,33 @@ This page lists the currently maintained Alauda AI versions in the component mat
 
 ## x86_64 Architecture
 
-| Components                                   | Type           | Alauda AI v2.3 Stable              | Alauda AI v2.4 Fast              |
+| Components                                   | Type           | Alauda AI v2.3 Stable              | Alauda AI v2.5 Fast              |
 | -------------------------------------------- | -------------- | ---------------------------------- | -------------------------------- |
 | Alauda Container Platform Supported Versions |                | v4.0.x, v4.1.x, v4.2.x, v4.3.x     | v4.0.x, v4.1.x, v4.2.x, v4.3.x   |
-| Alauda AI Essentials                         | Cluster Plugin | v2.3.0                             | v2.4.0                           |
-| Alauda AI                                    | Operator       | v2.3.0                             | v2.4.0                           |
+| Alauda AI Essentials                         | Cluster Plugin | v2.3.0                             | v2.5.0                           |
+| Alauda AI                                    | Operator       | v2.3.0                             | v2.5.0                           |
 | Alauda AI Workbench                          | Cluster Plugin | v0.1.7                             | v0.1.8                           |
-| Alauda Build of KServe                       | Operator       | v0.16.0                            | v0.16.0                          |
+| Alauda Build of KServe                       | Operator       | v0.16.0                            | v0.16.1                          |
 | Alauda Build of KubeRay Operator             | Cluster Plugin | v1.6.0                             | v1.6.0                           |
 | Alauda Build of NVIDIA GPU Device Plugin     | Cluster Plugin | v0.18.4                            | v0.18.4                          |
 | Alauda Build of NVIDIA DRA Driver for GPUs   | Cluster Plugin | v25.8.1                            | v25.8.1                          |
 | Alauda Build of DCGM-Exporter                | Cluster Plugin | v4.2.3-413-1                       | v4.2.3-413-1                     |
-| Alauda Build of HAMi                         | Cluster Plugin | v2.8.1                             | v2.8.1                           |
+| Alauda Build of HAMi                         | Cluster Plugin | v2.8.1                             | v2.8.3                           |
 | Alauda Build of HAMi-WebUI                   | Cluster Plugin | v1.10.0                            | v1.10.0                          |
 | Alauda Build of Node Feature Discovery       | Cluster Plugin | v0.17.4                            | v0.17.4                          |
 | Alauda Build of Kueue                        | Cluster Plugin | v0.17.0                            | v0.17.0                          |
 | Alauda Build of LeaderWorkerSet              | Cluster Plugin | v0.8.0-1                           | v0.8.0-1                         |
+| Alauda Build of JobSet                       | Cluster Plugin | -                                  | v0.12.0                          |
 | Volcano                                      | Cluster Plugin | v1.12.4                            | v1.12.4                          |
 | MLFlow                                       | Cluster Plugin | v3.1.5                             | v3.10.0                          |
 | Kubeflow Base                                | Cluster Plugin | v1.10.14-1                         | v1.11.0                          |
 | Kubeflow Pipelines (2)                       | Cluster Plugin | v1.10.13                           | v1.11.0                          |
 | Kubeflow Trainer v2 (1)                      | Cluster Plugin | v1.10.13                           | v1.11.0                          |
 | Kubeflow Model Registry                      | Operator       | v1.10.13                           | v0.3.8                           |
-| Alauda build of Llama Stack                  | Operator       | v0.8.0                             | v0.8.0                           |
+| Alauda build of Llama Stack                  | Operator       | v0.8.0                             | v0.9.0                           |
 | Label Studio                                 | Helm Charts    | v1.21.0-2                          | v1.21.0-2                        |
-| Alauda build of Envoy AI Gateway             | Cluster Plugin | v0.4.1                             | v0.4.1                           |
+| Alauda build of Envoy AI Gateway             | Cluster Plugin | v0.4.1                             | -                                |
+| Alauda build of Envoy AI Gateway             | Operator       | -                                  | v0.4.2                           |
 | Dify                                         | Helm Charts    | v1.11.4                            | v1.11.4                          |
 | Langflow                                     | Helm Charts    | v1.6.4-1                           | v1.6.4-1                         |
 | Evidently                                    | Helm Charts    | v0.7.14-1                          | v0.7.14-1                        |
@@ -46,31 +48,33 @@ This page lists the currently maintained Alauda AI versions in the component mat
 
 ## ARM Architecture
 
-| Components                                   | Type           | Alauda AI v2.3 Stable              | Alauda AI v2.4 Fast              |
+| Components                                   | Type           | Alauda AI v2.3 Stable              | Alauda AI v2.5 Fast              |
 | -------------------------------------------- | -------------- | ---------------------------------- | -------------------------------- |
 | Alauda Container Platform Supported Versions |                | v4.0.x, v4.1.x, v4.2.x, v4.3.x     | v4.0.x, v4.1.x, v4.2.x, v4.3.x   |
-| Alauda AI Essentials                         | Cluster Plugin | v2.3.0                             | v2.4.0                           |
-| Alauda AI                                    | Operator       | v2.3.0                             | v2.4.0                           |
+| Alauda AI Essentials                         | Cluster Plugin | v2.3.0                             | v2.5.0                           |
+| Alauda AI                                    | Operator       | v2.3.0                             | v2.5.0                           |
 | Alauda AI Workbench                          | Cluster Plugin | v0.1.7                             | v0.1.8                           |
-| Alauda Build of KServe                       | Operator       | v0.16.0                            | v0.16.0                          |
+| Alauda Build of KServe                       | Operator       | v0.16.0                            | v0.16.1                          |
 | Alauda Build of KubeRay Operator             | Cluster Plugin | v1.6.0                             | v1.6.0                           |
 | Alauda Build of NVIDIA GPU Device Plugin     | Cluster Plugin | v0.18.4                            | v0.18.4                          |
 | Alauda Build of NVIDIA DRA Driver for GPUs   | Cluster Plugin | v25.8.1                            | v25.8.1                          |
 | Alauda Build of DCGM-Exporter                | Cluster Plugin | v4.2.3-413-1                       | v4.2.3-413-1                     |
 | Alauda Build of NPU Operator (3)             | Cluster Plugin | v1.1.3                             | v1.1.3                           |
-| Alauda Build of HAMi                         | Cluster Plugin | v2.8.1                             | v2.8.1                           |
+| Alauda Build of HAMi                         | Cluster Plugin | v2.8.1                             | v2.8.3                           |
 | Alauda Build of HAMi-WebUI                   | Cluster Plugin | v1.10.0                            | v1.10.0                          |
 | Alauda Build of Node Feature Discovery       | Cluster Plugin | v0.17.4                            | v0.17.4                          |
 | Alauda Build of Kueue                        | Cluster Plugin | v0.17.0                            | v0.17.0                          |
 | Alauda Build of LeaderWorkerSet              | Cluster Plugin | v0.8.0-1                           | v0.8.0-1                         |
+| Alauda Build of JobSet                       | Cluster Plugin | -                                  | v0.12.0                          |
 | Volcano                                      | Cluster Plugin | v1.12.4                            | v1.12.4                          |
 | MLFlow                                       | Cluster Plugin | v3.1.5                             | v3.10.0                          |
 | Kubeflow Base                                | Cluster Plugin | v1.10.14-1                         | v1.11.0                          |
 | Kubeflow Trainer v2 (1)                      | Cluster Plugin | v1.10.13                           | v1.11.0                          |
 | Kubeflow Model Registry                      | Operator       | v1.10.13                           | v0.3.8                           |
-| Alauda build of Llama Stack                  | Operator       | v0.8.0                             | v0.8.0                           |
+| Alauda build of Llama Stack                  | Operator       | v0.8.0                             | v0.9.0                           |
 | Label Studio                                 | Helm Charts    | v1.21.0-2                          | v1.21.0-2                        |
-| Alauda build of Envoy AI Gateway             | Cluster Plugin | v0.4.1                             | v0.4.1                           |
+| Alauda build of Envoy AI Gateway             | Cluster Plugin | v0.4.1                             | -                                |
+| Alauda build of Envoy AI Gateway             | Operator       | -                                  | v0.4.2                           |
 | Dify                                         | Helm Charts    | v1.11.4                            | v1.11.4                          |
 | Langflow                                     | Helm Charts    | v1.6.4-1                           | v1.6.4-1                         |
 | Evidently                                    | Helm Charts    | v0.7.14-1                          | v0.7.14-1                        |
@@ -88,3 +92,5 @@ This page lists the currently maintained Alauda AI versions in the component mat
 (2) 'Featureform' and 'Kubeflow Pipelines' are only supported on x86_64 architecture
 
 (3) 'Alauda Build of NPU Operator' is only supported on ARM architecture
+
+(4) 'Alauda build of Envoy AI Gateway' has been refactored from a Cluster Plugin to an Operator in Alauda AI v2.5


### PR DESCRIPTION
Update AI 2.5 supported configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated supported configurations documentation reflecting Alauda AI v2.5 Fast (replacing v2.4) across both x86_64 and ARM architectures
* Upgraded multiple component versions including Essentials/Operator, KServe, HAMi, Llama Stack, and newly added JobSet support
* Enhanced documentation with clarifications regarding Envoy AI Gateway component deployment configurations
* Continued support for Alauda AI v2.3 Stable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/aml-docs/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->