### PR TITLE
docs: add coding-agents + MLOps how-tos for on-prem LLMs

### DIFF
--- a/docs/en/model_inference/inference_service/how_to/coding_agents_with_inference_service.mdx
+++ b/docs/en/model_inference/inference_service/how_to/coding_agents_with_inference_service.mdx
@@ -132,22 +132,44 @@ wire_api = "chat"
 
 ### Claude Code \{#claude-code}
 
-Claude Code communicates over the Anthropic Messages API (`/v1/messages`), which vLLM does not serve. Run a small gateway that accepts Anthropic-format requests and forwards them to your OpenAI-compatible endpoint. Two common options:
+Claude Code communicates over the Anthropic Messages API (`/v1/messages`). There are two ways to back it with an on-premise model — pick the one that matches your runtime.
+
+#### Option A: point Claude Code directly at the on-premise endpoint
+
+If the on-premise endpoint already speaks the Anthropic Messages API — either natively (for example, some `llama.cpp` `llama-server` builds and similar local runners) or because you front your `InferenceService` with a gateway that exposes `/v1/messages` — you can configure Claude Code with environment variables alone, no separate proxy needed:
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:9123"      # on-premise endpoint speaking the Anthropic Messages API
+export ANTHROPIC_AUTH_TOKEN="not_set"                  # any value; the endpoint may ignore it
+export ANTHROPIC_API_KEY="not_set_either!"             # any value; both vars are checked
+export ANTHROPIC_MODEL="qwen-2"                        # must match what the endpoint exposes (e.g. served-model-name)
+
+# Keep traffic on-premise and trim features the on-prem model can't honor:
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1      # suppress optional traffic to Anthropic-hosted services
+export CLAUDE_CODE_ATTRIBUTION_HEADER=0                # drop the Anthropic attribution header
+export CLAUDE_CODE_ENABLE_TELEMETRY=0                  # disable telemetry
+export CLAUDE_CODE_DISABLE_1M_CONTEXT=1                # disable the 1M-context feature; most on-prem models can't serve it
+export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000             # cap to what the on-prem model and runtime support
+
+claude
+```
+
+A few notes on the values:
+
+- The `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` values must be non-empty but their content does not matter if your endpoint does not check them; gate access at the endpoint or in front of it (see [Manage gateways](./mlops_with_coding_agents.mdx#manage-gateways) for adding auth via Envoy AI Gateway).
+- `ANTHROPIC_MODEL` must match the model name the endpoint exposes (the `--served-model-name` from your `InferenceService`, or whatever your local runner advertises).
+- The `CLAUDE_CODE_DISABLE_*` and `CLAUDE_CODE_*=0` flags are what actually keep an "on-prem" setup on-prem: without them, Claude Code can still emit non-essential requests to Anthropic-hosted endpoints and ask the model for features (1M context, very large outputs) the on-prem model cannot honor.
+
+#### Option B: front an OpenAI-compatible endpoint with a translation proxy
+
+If your endpoint is OpenAI-compatible only (for example, a stock vLLM `InferenceService` exposing `/v1/chat/completions` but not `/v1/messages`), run a small gateway that accepts Anthropic-format requests and forwards them. Two common options:
 
 - [LiteLLM](https://docs.litellm.ai/) proxy, which exposes an Anthropic-compatible `/v1/messages` endpoint and routes to any backend model.
 - [claude-code-router](https://github.com/musistudio/claude-code-router), a proxy built specifically to point Claude Code at OpenAI-compatible and other backends.
 
-Once the gateway is running, point Claude Code at it with environment variables:
+Then use the same env-var configuration from Option A, with `ANTHROPIC_BASE_URL` pointing at the proxy and `ANTHROPIC_MODEL` set to the model alias the proxy exposes. Optionally also set `ANTHROPIC_SMALL_FAST_MODEL` to an on-prem model so background/low-cost requests stay on-prem too.
 
-```bash
-export ANTHROPIC_BASE_URL="http://localhost:4000"   # the Anthropic-compatible gateway
-export ANTHROPIC_AUTH_TOKEN="sk-local"              # token the gateway expects
-export ANTHROPIC_MODEL="qwen-2"                     # main model (maps to your InferenceService)
-export ANTHROPIC_SMALL_FAST_MODEL="qwen-2"          # background/low-cost model
-claude
-```
-
-Map both the main model and the small/fast model to on-premise models so that no request silently falls back to a hosted provider. Agentic quality with Claude Code depends heavily on the served model's tool-calling fidelity; prefer a strong instruction- and tool-tuned model, and confirm tool calls round-trip through the gateway.
+Regardless of which option you pick, Claude Code's agentic quality depends heavily on the served model's tool-calling fidelity — prefer a strong instruction- and tool-tuned model, and confirm tool calls round-trip end-to-end before relying on it.
 
 ## Best practices \{#best-practices}
 

--- a/docs/en/model_inference/inference_service/how_to/coding_agents_with_inference_service.mdx
+++ b/docs/en/model_inference/inference_service/how_to/coding_agents_with_inference_service.mdx
@@ -1,0 +1,229 @@
+---
+weight: 17
+i18n:
+  title:
+    en: Use Coding Agents with On-Premise Inference Services
+    zh: 将编码智能体与本地部署的推理服务结合使用
+---
+
+# Use Coding Agents with On-Premise Inference Services
+
+## Introduction
+
+Coding agents such as [opencode](https://opencode.ai/), [Codex CLI](https://github.com/openai/codex), and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) are terminal-based assistants that read your repository, plan changes, edit files, and run commands on your behalf. They normally talk to a hosted model provider over the internet.
+
+This document shows how to point those agents at a model you serve yourself on Alauda AI, so that your source code, prompts, and infrastructure configuration never leave your cluster. The same on-premise `InferenceService` that you deploy for any other workload can back an interactive coding agent, as long as it exposes an **OpenAI-compatible API** and has **tool (function) calling** enabled.
+
+This page builds directly on the deployment how-tos. It does not repeat how to create or expose an `InferenceService`; instead it links to them and focuses on the agent-specific configuration and tuning.
+
+:::warning
+Coding agents and their configuration formats evolve quickly. The config snippets below are correct starting points for the versions available at the time of writing. Always confirm field names against the current upstream documentation of the agent you use.
+:::
+
+## Prerequisites
+
+- A running, ready `InferenceService` that serves an OpenAI-compatible API. See [Create Inference Service using CLI](./create_inference_service_cli.mdx).
+- Network access from the machine running the agent to the service endpoint. For access from a developer laptop outside the cluster, see [Configure External Access for Inference Services](./external_access_inference_service.mdx).
+- A model with **tool/function calling** support, served with the matching vLLM parser enabled (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)). Without this, agents can chat but cannot edit files or run commands.
+- The agent CLI installed locally (`opencode`, `codex`, or `claude`).
+
+## How the pieces fit together
+
+```text
+  Coding agent (opencode / Codex / Claude Code)
+        │  OpenAI-compatible HTTP  (POST /v1/chat/completions)
+        ▼
+  External access / Load Balancer  ──►  KServe InferenceService (vLLM)
+        ▲                                       │
+        └──── Anthropic→OpenAI proxy ───────────┘
+             (only required for Claude Code)
+```
+
+- **opencode** and **Codex CLI** speak the OpenAI Chat Completions API natively, so they can call the `InferenceService` endpoint directly.
+- **Claude Code** speaks the Anthropic Messages API, which vLLM does not serve. It requires a small translation proxy in front of the OpenAI-compatible endpoint (see [Claude Code](#claude-code)).
+
+## Step 1: Deploy and smoke-test the endpoint
+
+Deploy your model as an `InferenceService` following [Create Inference Service using CLI](./create_inference_service_cli.mdx), and if the agent runs outside the cluster, expose it following [Configure External Access for Inference Services](./external_access_inference_service.mdx).
+
+Before wiring up any agent, confirm the endpoint answers a chat request. Coding agents fail in confusing ways if the base URL, model name, or auth is wrong, so validate with `curl` first:
+
+```bash
+# BASE_URL must end at /v1
+BASE_URL="https://your-inference-service-domain.com/v1"
+MODEL="qwen-2"        # must match --served-model-name in the InferenceService
+API_KEY="sk-local"    # any non-empty value if the server does not enforce auth
+
+curl -sS ${BASE_URL}/chat/completions \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "'"${MODEL}"'",
+    "messages": [{"role": "user", "content": "Reply with the single word: ready"}],
+    "max_tokens": 16
+  }'
+```
+
+A normal JSON completion confirms the endpoint is reachable and the model name is correct. Note the three values you will reuse for every agent: **base URL** (ending in `/v1`), **model name** (the `--served-model-name`), and **API key**.
+
+## Step 2: Enable tool calling on the runtime \{#enable-tool-calling-on-the-runtime}
+
+Coding agents work by calling tools (read file, write file, run shell). This requires the model to emit tool calls **and** vLLM to parse them. Add the following flags to the vLLM launch command in your `InferenceService` (in the sample from [Create Inference Service using CLI](./create_inference_service_cli.mdx), they go on the `python3 -m vllm.entrypoints.openai.api_server` line):
+
+```bash
+--enable-auto-tool-choice \
+--tool-call-parser hermes        # match the parser to your model family
+```
+
+- The parser must match the model. For example, Qwen2.5 / Qwen3 family models commonly use `hermes`; Llama 3.x models use `llama3_json`; Mistral models use `mistral`. Check the [vLLM tool calling documentation](https://docs.vllm.ai/en/latest/features/tool_calling.html) for the current parser list and the value that matches your model.
+- Some models need a specific chat template to emit tool calls correctly; pass `--chat-template` if the model card calls for it.
+- If you serve a reasoning model, also enable the matching `--reasoning-parser` so the agent receives clean assistant content separated from reasoning traces.
+
+Verify tool calling end-to-end by asking the agent to perform a trivial file operation (for example, "create `hello.txt` containing the word hi"). If the model replies in prose instead of editing the file, tool calling is not wired up correctly — recheck the parser and model.
+
+## Step 3: Connect your coding agent
+
+### opencode
+
+opencode reads configuration from `opencode.json` in the project root or `~/.config/opencode/opencode.json`. Define a custom OpenAI-compatible provider that points at your endpoint:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "onprem": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "On-Prem Alauda AI",
+      "options": {
+        "baseURL": "https://your-inference-service-domain.com/v1",
+        "apiKey": "{env:ONPREM_API_KEY}"
+      },
+      "models": {
+        "qwen-2": {
+          "name": "Qwen2.5-Coder (on-prem)"
+        }
+      }
+    }
+  }
+}
+```
+
+- The model key (`qwen-2`) must match the `--served-model-name` of the `InferenceService`.
+- Export the key the config references, then select the model: `export ONPREM_API_KEY=sk-local` and choose `onprem/qwen-2` with the `/models` command inside opencode.
+
+### Codex CLI
+
+Codex CLI reads `~/.codex/config.toml`. Register your endpoint as a model provider and select it:
+
+```toml
+model = "qwen-2"
+model_provider = "onprem"
+
+[model_providers.onprem]
+name = "On-Prem Alauda AI"
+base_url = "https://your-inference-service-domain.com/v1"
+env_key = "ONPREM_API_KEY"
+wire_api = "chat"
+```
+
+- `base_url` must end at `/v1`; `model` must match the `--served-model-name`.
+- `env_key` names the environment variable that holds the API key: `export ONPREM_API_KEY=sk-local`.
+- Use `wire_api = "chat"` for vLLM's OpenAI Chat Completions API.
+
+### Claude Code \{#claude-code}
+
+Claude Code communicates over the Anthropic Messages API (`/v1/messages`), which vLLM does not serve. Run a small gateway that accepts Anthropic-format requests and forwards them to your OpenAI-compatible endpoint. Two common options:
+
+- [LiteLLM](https://docs.litellm.ai/) proxy, which exposes an Anthropic-compatible `/v1/messages` endpoint and routes to any backend model.
+- [claude-code-router](https://github.com/musistudio/claude-code-router), a proxy built specifically to point Claude Code at OpenAI-compatible and other backends.
+
+Once the gateway is running, point Claude Code at it with environment variables:
+
+```bash
+export ANTHROPIC_BASE_URL="http://localhost:4000"   # the Anthropic-compatible gateway
+export ANTHROPIC_AUTH_TOKEN="sk-local"              # token the gateway expects
+export ANTHROPIC_MODEL="qwen-2"                     # main model (maps to your InferenceService)
+export ANTHROPIC_SMALL_FAST_MODEL="qwen-2"          # background/low-cost model
+claude
+```
+
+Map both the main model and the small/fast model to on-premise models so that no request silently falls back to a hosted provider. Agentic quality with Claude Code depends heavily on the served model's tool-calling fidelity; prefer a strong instruction- and tool-tuned model, and confirm tool calls round-trip through the gateway.
+
+## Best practices \{#best-practices}
+
+### Choose a model that fits your hardware
+
+Start from the GPU memory you have, then pick the largest capable model that leaves headroom for the KV cache. A rough weight-size estimate is `parameters × bytes-per-parameter` — FP16 ≈ 2 bytes, FP8/INT8 ≈ 1 byte, INT4 ≈ 0.5 bytes per parameter — on top of which the KV cache and runtime overhead consume more memory. Leave **15–25% headroom**.
+
+| GPU memory (single GPU) | Example GPUs | Practical coding-model choices |
+| --- | --- | --- |
+| 16–24 GB | L4, A10, A30 (24G), RTX 4090 | 7–8B at FP16, or 14B quantized (AWQ/GPTQ INT4) |
+| 40–48 GB | A40, L40S, A6000, A100-40G | 14B at FP16, or 32B quantized (AWQ/GPTQ INT4) |
+| 80 GB | A100-80G, H100, H800 | 32B at FP16, or 70B at INT4 / FP8 |
+| Multi-GPU (2–8×) | 2–8 × 80 GB | 70B+ at FP16 with tensor parallel, or large MoE models |
+
+Additional selection guidance:
+
+- **Prefer code-specialized, instruction-tuned models** that natively support tool/function calling. If the model card does not mention tool calling, the agent will not be able to edit files reliably.
+- **Confirm a matching vLLM parser exists** for the model (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)) before committing to it.
+- **Budget for context length.** Coding agents send large prompts (system prompt + file and repo context). Pick a model whose context window covers your largest expected prompt, and remember that a longer `--max-model-len` consumes more KV cache per request, reducing concurrency.
+- **Quantization is a force multiplier on-premise.** INT4 (AWQ/GPTQ) or FP8 lets you fit a noticeably more capable model in the same VRAM, which usually matters more for agent quality than raw FP16 precision.
+
+### Tune inference service performance
+
+Coding-agent traffic has a distinctive shape: long, highly repetitive prompts (the same system prompt and repo context resent every turn), bursts of short interactive requests, and sensitivity to first-token latency. Tune for it:
+
+- **Enable prefix caching** (`--enable-prefix-caching`). This is the single highest-impact flag for coding agents: the shared prompt prefix is reused across turns instead of being recomputed, cutting prefill cost and latency dramatically. See [Automatic Prefix Caching — vLLM](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html).
+- **Raise `--gpu-memory-utilization`** toward `0.90–0.95` to enlarge the KV cache, which increases concurrency and the context length you can sustain.
+- **Right-size `--max-model-len`.** Set it to the largest context the agent actually needs, not the model's theoretical maximum — every extra token of capacity costs KV-cache memory.
+- **Enable chunked prefill** (`--enable-chunked-prefill`) when long prompts cause latency spikes under concurrency, so decode steps are not starved by a large prefill. Note the [CLI sample](./create_inference_service_cli.mdx) disables it by default.
+- **Allow CUDA graphs** for steady-state latency: the CLI sample sets `ENFORCE_EAGER=True` (eager mode, which starts faster but runs slower). Once the service is stable, switch to non-eager to capture CUDA graphs, at the cost of longer startup.
+- **Tune batching** with `--max-num-seqs` and `--max-num-batched-tokens` to balance throughput against per-request latency for your concurrency level.
+- **Use FP8 KV cache** (`--kv-cache-dtype fp8`) to stretch context length and concurrency when memory is tight.
+- **Shard large models** across GPUs with `--tensor-parallel-size` when a model does not fit on one card.
+- **Consider speculative decoding** for lower interactive latency on agent loops — see [Speculative Decoding for vLLM Inference Services](./vllm_speculative_decoding.mdx).
+- **Mind autoscaling and cold starts.** For interactive single-user agent use, keep `minReplicas: 1` — scaling from zero adds a multi-minute cold start that is painful mid-task. For bursty multi-developer usage, configure autoscaling deliberately; see [Configure Scaling for Inference Services](./autoscale_settings.mdx) and [Set Up Autoscaling for Inference Services with KEDA](./keda_autoscaling.mdx).
+- **Allow long requests.** Agent turns can be long-running; size the Knative `serving.knative.dev/progress-deadline` annotation and your client timeouts accordingly. If requests are cut off, see [Inference timeout troubleshooting](../trouble_shooting/infer_timeout.mdx).
+
+### Getting started with vibe coding
+
+"Vibe coding" — iterating quickly by describing intent and letting the agent write the code — works well with a self-hosted model once the basics are right:
+
+1. Start with a 7–14B code model that fits comfortably on your GPU with headroom; a responsive smaller model beats a sluggish larger one for interactive flow.
+2. Set a **low temperature** (around `0–0.2`) for code generation to keep edits deterministic and reduce flailing.
+3. Validate tool calling with one trivial task ("create a file and run it") before attempting anything real.
+4. Keep prompts focused — open or reference only the relevant files so the agent's context stays on-topic and prefill stays cheap.
+5. Work in small, reviewable steps and read each diff before accepting it. Commit often so you can roll back a bad suggestion cleanly.
+
+### Getting started with MLOps
+
+Because the model runs inside your cluster, a coding agent backed by an on-premise `InferenceService` is a good fit for operating the platform itself — your manifests, configs, and proprietary code never leave the environment, which matters in regulated settings. Productive starting tasks:
+
+- Generate or modify `InferenceService` YAML — for example, "write an `InferenceService` for model X targeting a 24 GB GPU with prefix caching and tool calling enabled."
+- Add autoscaling, scheduling, or resource configuration — KEDA/KPA autoscaling, CUDA-version-aware scheduling, or Kueue/Volcano queueing.
+- Author and adjust pipelines and monitoring for your model lifecycle.
+- Close the loop: deploy a model with the agent, then use that same on-premise model to drive further platform operations.
+
+## Troubleshooting
+
+- **Agent chats but never edits files or runs commands.** Tool calling is not enabled or the parser does not match the model — see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime).
+- **`model not found` / 404.** The model name in the agent config does not match the `--served-model-name`, or the base URL does not end in `/v1`.
+- **401 / 403.** The agent is sending the wrong (or no) API key for what the endpoint or gateway expects.
+- **Requests time out on long tasks.** Increase the Knative `progress-deadline` annotation and the client timeout — see [Inference timeout troubleshooting](../trouble_shooting/infer_timeout.mdx).
+- **First request after idle is very slow.** The service scaled to zero and is cold-starting; set `minReplicas: 1` for interactive use.
+
+## References
+
+- [Create Inference Service using CLI](./create_inference_service_cli.mdx)
+- [Configure External Access for Inference Services](./external_access_inference_service.mdx)
+- [Configure Scaling for Inference Services](./autoscale_settings.mdx)
+- [Set Up Autoscaling for Inference Services with KEDA](./keda_autoscaling.mdx)
+- [Speculative Decoding for vLLM Inference Services](./vllm_speculative_decoding.mdx)
+- [Extend Inference Runtimes](./custom_inference_runtime.mdx)
+- [Tool Calling — vLLM](https://docs.vllm.ai/en/latest/features/tool_calling.html)
+- [Automatic Prefix Caching — vLLM](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html)
+- [opencode documentation](https://opencode.ai/docs/)
+- [Codex CLI](https://github.com/openai/codex)
+- [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [LiteLLM](https://docs.litellm.ai/)
+- [claude-code-router](https://github.com/musistudio/claude-code-router)

--- a/docs/en/model_inference/inference_service/how_to/mlops_with_coding_agents.mdx
+++ b/docs/en/model_inference/inference_service/how_to/mlops_with_coding_agents.mdx
@@ -1,0 +1,266 @@
+---
+weight: 18
+i18n:
+  title:
+    en: Run MLOps with Coding Agents and On-Premise LLMs
+    zh: 使用编码智能体与本地部署 LLM 开展 MLOps
+---
+
+# Run MLOps with Coding Agents and On-Premise LLMs
+
+## Introduction
+
+Once a coding agent is wired to a self-hosted model on Alauda AI (see [Use Coding Agents with On-Premise Inference Services](./coding_agents_with_inference_service.mdx)), the same agent can drive day-to-day MLOps on the platform. Because both the model and the operations target the same cluster, prompts, manifests, training data references, and benchmark results never leave your environment — which is what makes self-hosted agents attractive for regulated work.
+
+This document describes four workflows where a coding agent is most useful:
+
+- Authoring and managing `InferenceService` and `LLMInferenceService` resources.
+- Configuring the inference traffic gateway — authentication and rate limits via [Alauda Build of Envoy AI Gateway](../../../envoy_ai_gateway/intro.mdx).
+- Iteratively tuning an inference service's performance to fit specific hardware.
+- Planning fine-tuning runs and generating structured reports from their results.
+
+It assumes you are already running the agent and that it can reach an on-premise OpenAI-compatible endpoint with **tool calling** enabled. If not, start with the prerequisites doc above.
+
+:::warning
+A coding agent that can run `kubectl` against a real cluster can also delete things. Scope its kubeconfig to a single namespace, prefer `--dry-run=server` for any apply during exploration, and require a human review of every change before it lands in production. Treat the agent like a junior engineer with cluster access, not an autonomous operator.
+:::
+
+## Set up the agent's working environment \{#set-up-environment}
+
+Before delegating MLOps work, give the agent a small, reliable context to operate in. Three things are almost always worth doing once per project:
+
+1. **Scope cluster access.** Create a dedicated namespace (for example, `mlops-demo-ai-test` used in the platform samples) and a `ServiceAccount` / kubeconfig with permissions limited to the resources the agent should touch — typically `InferenceService`, `LLMInferenceService`, `TrainJob`, `TrainingRuntime`, `AIGatewayRoute`, `AIServiceBackend`, `BackendSecurityPolicy`, `SecurityPolicy`, `BackendTrafficPolicy`, and the secrets/configmaps they reference. Avoid cluster-wide write access.
+2. **Pin a default hardware profile.** Platform Hardware Profiles encode the GPU type, taints, tolerations, and node selectors for your fleet. Pick the right profile up front and tell the agent to use it — this prevents the agent from inventing affinity blocks. See [Hardware Profiles](../../../infrastructure_management/hardware_profile/intro.mdx).
+3. **Commit an agent context file.** Most coding agents read a project-level instructions file (for example, `AGENTS.md`, `CLAUDE.md`, or `opencode.md`). Use it to record the cluster name, target namespace, the on-prem model endpoint, naming conventions, "always run `kubectl apply --dry-run=server` first", and any internal links the agent should follow. Once this file exists, every subsequent prompt becomes shorter and more accurate.
+
+## Manage InferenceServices and LLMInferenceServices \{#manage-inference-services}
+
+The platform supports two related resources for serving models:
+
+- **`InferenceService`** (`serving.kserve.io/v1beta1`) — the standard KServe predictor used in [Create Inference Service using CLI](./create_inference_service_cli.mdx). Best for single-container model servers (vLLM, Triton, custom runtimes).
+- **`LLMInferenceService`** — KServe's higher-level LLM resource for multi-component LLM serving (orchestrating predictors, optional prefill/decode disaggregation, and gateway/inference-extension integration). It is recognized by platform features such as Hardware Profiles, which mention it alongside `InferenceService` (see [Hardware Profiles](../../../infrastructure_management/hardware_profile/intro.mdx)). Use it when a single-container `InferenceService` is no longer enough.
+
+A good agent loop for either resource is the same:
+
+```text
+draft YAML  →  kubectl apply --dry-run=server  →  apply  →  poll status  →  smoke test  →  iterate
+```
+
+Useful prompts to start from:
+
+- "Generate an `InferenceService` for model `Qwen2.5-Coder-7B-Instruct` using the `aml-vllm` runtime, hardware profile `single-a30-24g`, namespace `mlops-demo-ai-test`. Enable prefix caching and tool calling with the `hermes` parser. Run `kubectl apply --dry-run=server` and show me the diff against any existing object before applying."
+- "Convert this `InferenceService` to an `LLMInferenceService` for prefill/decode disaggregation; keep the same model, hardware profile, and served-model name. Show me what changes and why."
+- "List all `InferenceService` and `LLMInferenceService` objects in `mlops-demo-ai-test`, their `READY` status, and the model each one serves. Flag any that have been `NotReady` for more than 10 minutes and summarize the most recent predictor pod events."
+
+For the YAML fields and platform-specific labels/annotations the agent needs to reproduce, point it at [Create Inference Service using CLI](./create_inference_service_cli.mdx) as the canonical example. For exposing a new service externally, point it at [Configure External Access for Inference Services](./external_access_inference_service.mdx).
+
+## Manage gateways: authentication and rate limits \{#manage-gateways}
+
+Alauda Build of Envoy AI Gateway is a required dependency of Alauda Build of KServe and fronts inference traffic with an OpenAI-compatible API surface, AI-aware routing, and per-model policies (see [Envoy AI Gateway introduction](../../../envoy_ai_gateway/intro.mdx) and [installation](../../../envoy_ai_gateway/install.mdx)). The agent is well-suited to author its CRDs, which are otherwise verbose:
+
+| Concern | CRD / Resource | Where it comes from |
+|---|---|---|
+| Route requests to one or more model backends | `AIGatewayRoute`, `AIServiceBackend` | Envoy AI Gateway |
+| Authenticate the **client** (downstream): API key, JWT, OIDC | `SecurityPolicy` | Envoy Gateway |
+| Authenticate to the **upstream** model (when chaining to a hosted provider) | `BackendSecurityPolicy` | Envoy AI Gateway |
+| Per-route or per-model rate limiting and token-budget enforcement | `BackendTrafficPolicy` (global rate limit) or `AIGatewayRoute` token-rate-limit settings | Envoy Gateway / Envoy AI Gateway |
+| TLS termination, observability | Standard `Gateway` / `HTTPRoute` and Envoy Gateway features | Envoy Gateway |
+
+A practical agent workflow:
+
+1. **Tell the agent your intent in business terms.** For example: "Expose `qwen-2` and `llama-3-70b` behind one OpenAI-compatible endpoint at `https://ai.example.internal`. Require an `Authorization: Bearer` API key from a Kubernetes `Secret` named `ai-gateway-keys`. Limit each key to 60 requests/minute and 200k tokens/hour. Send `qwen-2` traffic to the `qwen-2` `InferenceService` in `mlops-demo-ai-test` and `llama-3-70b` to the `LLMInferenceService` of the same name."
+2. **Have the agent draft the CRDs** in a directory under your infra repo, one file per resource, with comments calling out each policy decision.
+3. **Validate before applying.** Ask the agent to run `kubectl apply --dry-run=server -f ./gateway/` and to summarize what would change. Apply only after you review.
+4. **Smoke-test the new policies.** Have the agent send a valid request, an unauthenticated request, and a request that exceeds the rate limit, and confirm the expected 200 / 401 / 429 responses. Capture the test as a small script alongside the manifests so future changes can be re-verified.
+
+For the exact field shape of each CRD, defer to the upstream documentation linked below — versions change, and the agent should read the live spec rather than inventing fields.
+
+## Tune service performance to fit your hardware \{#tune-performance}
+
+The list of vLLM and KServe knobs is unchanged from [Best practices: tune inference service performance](./coding_agents_with_inference_service.mdx#best-practices) — this section focuses on how an agent can *drive* that tuning instead of you doing it by hand.
+
+A productive loop:
+
+<Steps>
+
+### 1. Define service-level objectives
+
+Pin numbers before tuning. Tell the agent what "good enough" looks like:
+
+- Maximum first-token latency (TTFT) at the expected concurrency.
+- Maximum P95 inter-token latency or total response time for a representative prompt.
+- Minimum sustainable throughput (requests/min or tokens/sec).
+- Maximum context length the agent traffic will send.
+
+### 2. Generate a reproducible benchmark
+
+Ask the agent to write a small benchmark script that mirrors your real traffic — typical prompt size, system prompt, concurrency. Useful starting points include the built-in `vllm bench serve` command, `genai-perf`, or a `k6`/Python script that drives `/v1/chat/completions` directly. Have the agent run it against the current `InferenceService` and record the results in a markdown table.
+
+### 3. Have the agent propose one change at a time
+
+Give the agent the benchmark output and the current YAML. Ask for **one** change with an expected effect, for example:
+
+- "Add `--enable-prefix-caching` and re-run; expected: lower TTFT on the repeated system-prompt prefix."
+- "Switch the model from FP16 to AWQ INT4 and raise `--gpu-memory-utilization` to 0.92; expected: more KV cache headroom, larger sustainable context length."
+- "Increase `--max-num-seqs`; expected: higher throughput at the cost of higher P95 latency."
+
+One change per iteration keeps cause and effect attributable.
+
+### 4. Apply, measure, and record
+
+The agent updates the `InferenceService` YAML, applies it, waits for `READY`, re-runs the benchmark, and appends a new row to the results table with the configuration delta.
+
+### 5. Stop on SLO or hardware ceiling
+
+The loop ends when SLOs are met, or when the next sensible knob is "different hardware" or "different model" — at which point the agent should say so explicitly rather than churn. Common ceilings: KV cache saturated at the target context length, tensor-parallel scaling no longer linear, decode-bound at single-request latency.
+
+</Steps>
+
+For model-size vs. GPU-memory selection, see the table in the prior doc's [Choose a model that fits your hardware](./coding_agents_with_inference_service.mdx#best-practices) section. For autoscaling and cold-start trade-offs, see [Configure Scaling for Inference Services](./autoscale_settings.mdx). For interactive-latency wins, see [Speculative Decoding for vLLM Inference Services](./vllm_speculative_decoding.mdx).
+
+## Plan fine-tuning and generate reports \{#fine-tuning-plans-and-reports}
+
+Fine-tuning has two failure modes that coding agents are unusually good at preventing: skipping the planning step ("just run SFT") and skipping the reporting step ("the loss looked fine"). The agent's job is to make both explicit.
+
+### Pick the right tool for the job
+
+| Situation | Recommended tool | Reference |
+|---|---|---|
+| Interactive exploration, small dataset, one or two GPUs | Workbench Notebook | [Fine-tuning with Notebooks](../../../workbench/how_to/fine_tunning_using_notebooks.mdx) |
+| Production-grade SFT / OSFT with automatic memory management | Training Hub | [Fine-tuning LLMs with Training Hub](../../../workbench/how_to/training_hub_fine_tuning.mdx) |
+| Reusable templates, many runs, scheduled / batched on Kueue | Kubeflow Trainer v2 + LlamaFactory | [Fine-Tuning with Kubeflow Trainer v2](../../../kubeflow/how_to/fine-tune-with-trainer-v2.mdx) |
+| Already-tuned model needs to fit a smaller GPU before serving | LLM Compressor | [LLM Compressor with Alauda AI](../../../llm-compressor/how_to/compressor_by_workbench.mdx) |
+
+### A reusable fine-tuning plan template
+
+Have the agent fill in this template **before** any job is submitted, and commit the result alongside the training code. This separates "what we intend" from "what we ran," which is exactly the comparison the report needs later.
+
+```markdown
+# Fine-tuning plan: <run-id>
+
+## Objective
+- Business goal:
+- Success metric (what improves; how it's measured):
+- Acceptance threshold (minimum acceptable score on the metric):
+
+## Base model
+- Model and revision:
+- Why this base (capability, license, context window, tool-calling support):
+
+## Dataset
+- Source(s) and license:
+- Size (examples / tokens):
+- Format (e.g., JSONL chat messages):
+- Splits (train / eval / held-out):
+- Known biases or contamination risks:
+
+## Method
+- Approach (SFT / LoRA / QLoRA / OSFT / continued pre-train):
+- Justification vs. the alternatives:
+- Tool (Training Hub / Kubeflow Trainer v2 / Notebook / LlamaFactory):
+
+## Compute budget
+- Hardware (GPU type, count, hours):
+- Hardware Profile to use:
+- Estimated cost / wall-clock:
+
+## Hyperparameters
+- Effective batch size, max_tokens_per_gpu, lr, epochs, scheduler, seed:
+- Checkpoint cadence and retention:
+
+## Evaluation plan
+- Benchmarks (public + internal):
+- Eval harness and seed:
+- Comparison baselines (the base model, prior runs):
+
+## Risks and rollback
+- What could go wrong (catastrophic forgetting, tool-calling regression, license conflict):
+- How we'll detect it:
+- Rollback (which model artifact to revert to):
+```
+
+Useful prompt: "Read `plan.md`. Draft a Kubeflow Trainer v2 `TrainingRuntime` and `TrainJob` (or a Training Hub notebook) that implements exactly this plan in namespace `mlops-demo-ai-test`. Highlight any field where the plan is ambiguous and ask me before guessing."
+
+### A reusable fine-tuning report template
+
+After the job finishes, ask the agent to ingest the training logs, eval outputs, and resource metrics, and fill in this report. Commit it next to the plan.
+
+```markdown
+# Fine-tuning report: <run-id>
+
+## Provenance
+- Plan: link to plan.md and its commit SHA
+- TrainJob / Notebook: name, namespace, start/end time
+- Hardware actually used (vs. planned):
+- Model artifact location (PVC / model repo path / OCI image):
+
+## Training summary
+- Steps / epochs completed:
+- Final training loss; loss trend (link to TensorBoard / MLflow run):
+- Throughput (tokens/sec, samples/sec):
+- Wall-clock and GPU-hours:
+- Anomalies (loss spikes, restarts, OOMs):
+
+## Evaluation results
+- Headline metric vs. baseline and acceptance threshold:
+- Per-benchmark scores table (this run, base model, prior best):
+- Tool-calling sanity check (pass/fail with example):
+- Qualitative samples (3–5 prompts; this run vs. base, side by side):
+
+## Cost
+- GPU-hours, $ (if applicable), $/percentage-point of improvement:
+
+## Decision
+- Promote / re-run / abandon:
+- If promote: which `InferenceService` to update and how (image, storageUri, runtime flags):
+- If re-run: what to change in the next plan.md:
+
+## Next actions
+- Owner / date:
+```
+
+Useful prompt: "Generate `report.md` for TrainJob `qwen-coder-sft-2026-05-29` in `mlops-demo-ai-test`. Pull metrics from MLflow run `<id>`, training logs from the pod, and eval results from `s3://aml-evals/<run-id>/`. Compare against the previous run `qwen-coder-sft-2026-05-15`. If any section can't be filled in from the available data, mark it `TODO` rather than fabricating numbers."
+
+For experiment tracking and run metadata, [MLflow on Kubeflow](../../../kubeflow/how_to/mlflow.mdx) is the platform-native option; tell the agent to log there from inside the training code so the report has a real source of truth.
+
+## A daily MLOps loop \{#daily-loop}
+
+A useful end-to-end sequence the agent can drive, given the setup above:
+
+1. **Triage.** "List inference services in my namespace, surface anything `NotReady` or scaled to zero unexpectedly, summarize recent gateway 4xx/5xx rates."
+2. **Tune.** "P95 on `qwen-2` is over budget. Propose one change, apply, re-benchmark, report."
+3. **Update.** "There's a new model artifact for `qwen-coder-sft-2026-05-29`. Draft the YAML to swap it into the `qwen-2` `InferenceService`, gate the rollout to one replica first, and write the smoke test."
+4. **Plan.** "Draft a fine-tuning plan to fix the tool-calling regression we saw in last week's eval. Justify the method choice."
+5. **Report.** "Last night's job finished. Generate the report and tell me whether to promote."
+
+Each step is a separate prompt with its own diff to review. The agent is the typist; you are still the engineer of record.
+
+## Best practices and guardrails \{#best-practices-and-guardrails}
+
+- **Read-only first, write second.** Start every new task by asking the agent to read state (`get`, `describe`, logs, metrics) and *describe what it would do* before making changes.
+- **Always `--dry-run=server`.** Make it a standing rule in the agent context file; mention it in every prompt that involves `kubectl apply`.
+- **One change per iteration.** Especially for performance tuning, mixing two changes hides which one helped.
+- **Never let the agent fabricate metrics.** Require it to cite the file, log, or run ID it pulled each number from, and to mark `TODO` when data is missing.
+- **Keep the loop on-prem.** Confirm that no fallback model in any agent config points at a hosted provider (see [Connect your coding agent](./coding_agents_with_inference_service.mdx) for the per-agent settings to check).
+- **Commit everything.** Plans, reports, generated YAML, and benchmark scripts all go into Git so the next person — or the next agent — can pick up where you left off.
+
+## References
+
+- [Use Coding Agents with On-Premise Inference Services](./coding_agents_with_inference_service.mdx)
+- [Create Inference Service using CLI](./create_inference_service_cli.mdx)
+- [Configure External Access for Inference Services](./external_access_inference_service.mdx)
+- [Configure Scaling for Inference Services](./autoscale_settings.mdx)
+- [Speculative Decoding for vLLM Inference Services](./vllm_speculative_decoding.mdx)
+- [Extend Inference Runtimes](./custom_inference_runtime.mdx)
+- [Envoy AI Gateway — introduction](../../../envoy_ai_gateway/intro.mdx)
+- [Install Envoy AI Gateway](../../../envoy_ai_gateway/install.mdx)
+- [Hardware Profiles](../../../infrastructure_management/hardware_profile/intro.mdx)
+- [Fine-Tuning with Kubeflow Trainer v2](../../../kubeflow/how_to/fine-tune-with-trainer-v2.mdx)
+- [Fine-tuning LLMs with Training Hub](../../../workbench/how_to/training_hub_fine_tuning.mdx)
+- [Fine-tuning with Notebooks](../../../workbench/how_to/fine_tunning_using_notebooks.mdx)
+- [LLM Compressor with Alauda AI](../../../llm-compressor/how_to/compressor_by_workbench.mdx)
+- [MLflow on Kubeflow](../../../kubeflow/how_to/mlflow.mdx)
+- [Envoy AI Gateway upstream documentation](https://aigateway.envoyproxy.io/)
+- [Envoy Gateway upstream documentation](https://gateway.envoyproxy.io/)
+- [KServe LLMInferenceService](https://kserve.github.io/website/)
+- [vLLM benchmarking](https://docs.vllm.ai/en/latest/serving/usage_stats.html)


### PR DESCRIPTION
## Summary

Adds two stacked how-tos under `model_inference/inference_service/how_to`, building on each other:

### 1. `coding_agents_with_inference_service.mdx` — Use Coding Agents with On-Premise Inference Services

Connect terminal coding agents to a self-hosted, OpenAI-compatible `InferenceService` so source code and prompts never leave the cluster:

- Builds on and links to the existing **Create Inference Service using CLI** and **Configure External Access** how-tos rather than repeating them.
- Adds a `curl` smoke test for validating the endpoint (base URL / model name / API key).
- Shows how to enable **tool (function) calling** on the vLLM runtime — the prerequisite that lets agents actually edit files and run commands.
- Per-agent connection config for **opencode**, **Codex CLI**, and **Claude Code** (the latter via an Anthropic→OpenAI translation proxy such as LiteLLM or claude-code-router).
- Best practices: a GPU-memory→model-size table, performance tuning for agent traffic (prefix caching, GPU memory utilization, chunked prefill, CUDA graphs, quantization, autoscaling/cold-start trade-offs), and getting-started guidance for vibe coding and MLOps workflows.

### 2. `mlops_with_coding_agents.mdx` — Run MLOps with Coding Agents and On-Premise LLMs

Once the agent is wired up, the same agent drives day-to-day MLOps:

- **Manage `InferenceService` / `LLMInferenceService`** — agent loop (draft → `kubectl apply --dry-run=server` → apply → poll → smoke-test) with concrete starter prompts.
- **Configure Envoy AI Gateway** — auth and rate limits via `AIGatewayRoute`, `AIServiceBackend`, `BackendSecurityPolicy`, `SecurityPolicy`, and `BackendTrafficPolicy`. Cross-links the existing envoy_ai_gateway intro/install docs.
- **Agent-driven performance tuning loop** — five steps: SLOs → reproducible benchmark → one change per iteration → measure → stop on SLO or hardware ceiling. Cross-links into doc 1's tuning section instead of duplicating the flag list.
- **Fine-tuning plans and reports** — a tool-selection table (Notebook / Training Hub / Kubeflow Trainer v2 / LLM Compressor) plus two ready-to-commit markdown templates: a pre-run *plan* and a post-run *report* designed for the agent to fill in from MLflow runs, training logs, and eval outputs.
- Adds a "daily MLOps loop" walk-through and guardrails (read-only first, server-side dry-run by default, one change per iteration, no fabricated metrics, no hosted-provider fallback).

## Test plan

- [x] `doom lint` passes on both files (0 errors, 0 warnings)
- [x] Pre-commit `yarn lint` passes
- [x] All internal cross-links to existing docs (inference_service how-tos and troubleshooting, envoy_ai_gateway, kubeflow, workbench, llm-compressor, infrastructure_management/hardware_profile) resolve
- [ ] Reviewer: verify rendered pages and the two markdown templates render cleanly inside fenced code blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for using terminal-based coding agents with self-hosted inference service instances, including setup instructions, agent configuration, and performance tuning tips.
  * Added documentation covering MLOps workflows powered by coding agents on on-premise infrastructure, with guidance on resource management, performance optimization, and operational best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/aml-docs/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->