### PR TITLE
docs(kubeflow): align with v26.3.0 OLM operator install path

### DIFF
--- a/docs/en/kubeflow/faq.mdx
+++ b/docs/en/kubeflow/faq.mdx
@@ -19,36 +19,56 @@ kubectl label --overwrite ns [NAMESPACE_NAME] pod-security.kubernetes.io/warn=ba
 
 In some environments, the platform access address is configured as an internal network address, and users need to log in through an "Alternative Platform Address." In this scenario, while the OIDC issuer remains based on the original platform address, the login page URL must be updated to the alternative address.
 
-Steps:  
+### v26.3.0 and later (OLM operator install)
 
-- Locate the ModuleInfo Resource:
+Steps:
 
-In the global cluster, find the ModuleInfo resource corresponding to the kfbase  plugin using the following command:
+- **Locate the `KubeflowBase` CR** for the kfbase-operator install in the operator-instance namespace:
 
-```shell
-kubectl get moduleinfoes -l cpaas.io/module-name=kfbase,cpaas.io/cluster-name=<deployed-cluster-name>
-```
+  ```shell
+  kubectl get kubeflowbase -A
+  ```
 
-- Edit the ModuleInfo Resource
+- **Edit the `KubeflowBase` CR**. Add `oidcAuthURL` under `spec.global`. Replace `<Alternative-Platform-Address>` with the actual alternative address.
 
-Add the valuesOverride  section under spec  as shown below. Replace `<Alternative-Platform-Address>` with the actual alternative address.
-
-```yaml
-......
-spec: 
-  valuesOverride: 
-    mlops/kfbase:  
+  ```yaml
+  spec:
+    global:
       oidcAuthURL: https://<Alternative-Platform-Address>/dex/auth
-......
-```
+  ```
+
+  The kfbase-operator's helm-operator reconcile loop applies the change to the underlying chart release.
+
+- **Restart the OAuth2 Proxy** in the target cluster:
+
+  ```shell
+  kubectl rollout restart deploy -n kubeflow-oauth2-proxy oauth2-proxy
+  ```
+
+### v1.x (Cluster Plugin install — legacy)
+
+Steps:
+
+- Locate the ModuleInfo Resource in the global cluster:
+
+  ```shell
+  kubectl get moduleinfoes -l cpaas.io/module-name=kfbase,cpaas.io/cluster-name=<deployed-cluster-name>
+  ```
+
+- Edit the ModuleInfo Resource. Add `valuesOverride` under `spec`:
+
+  ```yaml
+  spec:
+    valuesOverride:
+      mlops/kfbase:
+        oidcAuthURL: https://<Alternative-Platform-Address>/dex/auth
+  ```
 
 - Restart the OAuth2 Proxy:
 
-Apply the changes by restart the oauth2-proxy  deployment in the target cluster:
-
-```shell
-kubectl rollout restart deploy -n kubeflow-oauth2-proxy oauth2-proxy
-```
+  ```shell
+  kubectl rollout restart deploy -n kubeflow-oauth2-proxy oauth2-proxy
+  ```
 
 ## How to start a Kubeflow Pipeline Run with external S3/MinIO storage
 

--- a/docs/en/kubeflow/install.mdx
+++ b/docs/en/kubeflow/install.mdx
@@ -1,36 +1,39 @@
 ---
 weight: 20
 ---
-# Install Kubeflow Plugins
+# Install Kubeflow Operators
 
-This page describes how to deploy Kubeflow-related plugins in Alauda AI 2.0 and later.
+This page describes how to deploy Kubeflow-related operators in Alauda AI 2.0 and later.
 
-Supported plugins:
+Starting in **v26.3.0** (Alauda AI v2.3), Kubeflow ships as OLM Helm Operators rather than the earlier Cluster Plugin form factor. Installation is performed from the ACP **OperatorHub** instead of **Cluster Plugins**. The operators wrap the upstream `kubeflow/manifests` 26.03 charts.
 
-- `kfbase`: Kubeflow base components, including authentication and authorization, the central dashboard, Notebooks, PVC Viewer, TensorBoards, Volumes, Model Registry UI, KServe Endpoints UI, and the Model Catalog API service.
-- `model-registry-operator`: Kubeflow Model Registry Operator.
-- `kfp`: Kubeflow Pipelines.
-- `kftraining`: Kubeflow Training Operator. This plugin is deprecated.
-- `kubeflow-trainer`: Kubeflow Trainer v2 for training job management. This plugin replaces `kftraining`.
+Supported operators:
+
+- `kfbase-operator`: Kubeflow base components, including authentication and authorization, the central dashboard, Notebooks, PVC Viewer, TensorBoards, Volumes, Model Registry UI, KServe Endpoints UI, and the Model Catalog API service. Owns the `KubeflowBase` CR. Architecture: `amd64`, `arm64`.
+- `kfp-operator`: Kubeflow Pipelines (KFP runtime 2.16.0). Owns the `KubeflowPipelines` CR. **Architecture: `amd64` only** (Kubeflow Pipelines is x86_64-only per Alauda AI v2.3 supported configurations).
+- `kubeflow-trainer-operator`: Kubeflow Trainer v2 (controller-manager 2.1.0 + JobSet 0.10.1). Owns the `KubeflowTrainer` CR. Architecture: `amd64`, `arm64`. Replaces the deprecated `kftraining` plugin.
+- `model-registry-operator`: Kubeflow Model Registry Operator (unchanged form factor).
+
+> **Note:** The `kftraining` Cluster Plugin (Kubeflow Training Operator v1) was deprecated in earlier versions and has been retired in v26.3.0. Use `kubeflow-trainer-operator` (Trainer v2) instead.
 
 ## Environment Preparation
 
 Before you begin, make sure the following prerequisites are met:
 
 1. An ACP environment is available and running.
-2. Alauda AI is already deployed. Alauda AI 2.0 or later is required.
+2. Alauda AI is already deployed. Alauda AI 2.3 or later is required for the v26.3.0 operator set.
 3. Alauda Build of KServe is installed.
 4. ASM is deployed in the business cluster where Kubeflow will run. If ASM is not already installed, deploy it before continuing. ASM v1 is deprecated. Use ASM v2 whenever possible.
-5. The LWS plugin, Alauda Build of LeaderWorkerSet, is installed if you plan to deploy `kubeflow-trainer`.
+5. The LWS plugin, Alauda Build of LeaderWorkerSet, is installed if you plan to deploy `kubeflow-trainer-operator`.
 6. The `oauth2-proxy` plugin is configured as described below.
 
 ### Configure Dex Redirection
 
-> **Note:** Configure the platform access URL for Dex redirection before installing the `kfbase` plugin. This step may update the platform CA certificate. If the certificate changes after you configure `oauth2-proxy`, the `oauth2-proxy` configuration may fail.
+> **Note:** Configure the platform access URL for Dex redirection before installing the `kfbase-operator` and creating its `KubeflowBase` CR. This step may update the platform CA certificate. If the certificate changes after you configure `oauth2-proxy`, the `oauth2-proxy` configuration may fail.
 
 In **Administrator** > **System Settings** > **Platform Parameters**, click **Edit** next to **Platform Access URLs** and add a redirect URL in the format `https://<your-kubeflow-domain>`, for example `https://kubeflow.example.com`.
 
-- `<your-kubeflow-domain>` must match the `kubeflowDomain` value configured for the `kfbase` plugin.
+- `<your-kubeflow-domain>` must match the `kubeflowDomain` field configured in the `KubeflowBase` CR (`spec.global.kubeflowHost`).
 
 ### Configure the `oauth2-proxy` Plugin
 
@@ -129,38 +132,35 @@ spec:
 
 ## Component Onboarding
 
-Download the installation packages for the following plugins and upload them with `violet`:
+Download the operator bundle packages for the following operators and upload them with `violet`. The bundles register the operators with the ACP OperatorHub.
 
 ```bash
-# Replace the platform address, username, password, and plugin package path.
+# Replace the platform address, username, password, and bundle package path.
 violet push --platform-address="https://192.168.171.123" \
   --platform-username="admin@cpaas.io" \
   --platform-password="<platform_password>" \
-  <your-downloaded-plugin-package-file>
+  <your-downloaded-operator-bundle-package-file>
 ```
 
-- `kfbase`: Kubeflow base functionality.
+- `kfbase-operator`: Kubeflow base functionality (owns `KubeflowBase` CR).
+- `kfp-operator`: Kubeflow Pipelines (owns `KubeflowPipelines` CR). amd64-only.
+- `kubeflow-trainer-operator`: Kubeflow Trainer v2 (owns `KubeflowTrainer` CR). Replaces the deprecated `kftraining`.
 - `model-registry-operator`: Kubeflow Model Registry Operator.
-- `kfp`: Kubeflow Pipelines.
-- `kftraining`: Kubeflow Training Operator. This plugin is deprecated.
-- `kubeflow-trainer`: Kubeflow Trainer v2. This plugin replaces `kftraining`.
-
-> **Note:** If you want to enable Volcano scheduler support for `kftraining`, deploy Volcano before installing `kftraining`.
 
 ## Deployment Steps
 
-### 1. Deploy `kfbase` (Kubeflow Base)
+### 1. Deploy `kfbase-operator` (Kubeflow Base)
 
-In **Cluster Plugins**, find the `kfbase` plugin, complete the configuration on the page, and wait for the deployment to finish.
+In **Administrator** > **MarketPlace** > **OperatorHub**, find the `kfbase-operator` and click **Install**. Then open the **All Instances** tab and create a `KubeflowBase` CR with `spec.global.kubeflowHost` set to your Kubeflow domain. Wait for the deployment to finish.
 
 After deployment:
 
-- In **Administrator** > **System Settings** > **Platform Parameters**, verify that **Platform Access URLs** contains an address in the format `https://<your-kubeflow-domain>`, where `<your-kubeflow-domain>` is the `kubeflowDomain` configured for the `kfbase` plugin.
+- In **Administrator** > **System Settings** > **Platform Parameters**, verify that **Platform Access URLs** contains an address in the format `https://<your-kubeflow-domain>`, where `<your-kubeflow-domain>` matches `spec.global.kubeflowHost` in the `KubeflowBase` CR.
 - Configure DNS resolution, or add a local hosts entry, so that `<your-kubeflow-domain>` resolves to the IP address assigned to `kubectl -n istio-system get gateway kubeflow-external-gateway`.
 
 After deployment, the Kubeflow entry appears under **Tools** in Alauda AI.
 
-For upgrade-specific actions, see [Upgrade Kubeflow Plugins](./upgrade).
+For upgrade-specific actions, see [Upgrade Kubeflow Operators](./upgrade).
 
 ### 2. Create a Kubeflow User Namespace and Bind a User
 
@@ -251,13 +251,13 @@ spec:
             - "admin@cpaas.io"
 ```
 
-### 4. Deploy `kfp` and `kftraining` (Deprecated)
+### 4. Deploy `kfp-operator` (Kubeflow Pipelines)
 
-In **Cluster Plugins**, find `kfp` and `kftraining` and deploy them as needed.
+In **Administrator** > **MarketPlace** > **OperatorHub**, find the `kfp-operator` and click **Install**. Then create a `KubeflowPipelines` CR in the operator instance namespace. After the CR reconciles, KFP runtime components are deployed and pipeline-related features become available in the Kubeflow UI.
 
-> **Note:** After `kfp` is deployed, pipeline-related features become available in the Kubeflow UI.
+> **Note:** `kfp-operator` is amd64-only. Do not install it on arm64-only clusters.
 >
-> **Note:** `kftraining` is a background controller. It does not appear as a menu item in the Kubeflow UI.
+> **Note:** Pipeline-related features become available in the Kubeflow UI only after `KubeflowPipelines` is reconciled.
 
 ### 5. Deploy Kubeflow Model Registry
 
@@ -282,12 +282,12 @@ When creating the instance, configure the following fields as needed:
 >
 > **Note:** You can deploy multiple Model Registry instances in different namespaces. Each instance is independent.
 
-### 6. Deploy `kubeflow-trainer` (Kubeflow Trainer v2)
+### 6. Deploy `kubeflow-trainer-operator` (Kubeflow Trainer v2)
 
-> **Note:** If `kftraining` is already deployed, uninstall it before deploying `kubeflow-trainer`.
+> **Note:** If the deprecated `kftraining` Cluster Plugin is still installed (from a pre-v26.3.0 cluster), uninstall it before installing `kubeflow-trainer-operator`.
 >
-> **Note:** Install the LWS plugin before deploying `kubeflow-trainer`, because LWS is a dependency of `kubeflow-trainer`.
+> **Note:** Install the LWS plugin before deploying `kubeflow-trainer-operator`, because LWS is a dependency of `kubeflow-trainer`.
 >
-> **Note:** Kubeflow Trainer v2 requires Kubernetes `1.32.3` or later. Older Kubernetes versions may lead to unexpected behavior.
+> **Note:** v26.3.0 of `kubeflow-trainer-operator` aligns with upstream `kubeflow/manifests` 26.03 and ships **Trainer v2.1.0 + JobSet v0.10.1**. For clusters where an OLM CatalogSource already advertises a higher trainer version (`>=2.2.0`), install with `installPlanApproval: Manual` and `startingCSV: kubeflow-trainer-operator.v2.1.0` to prevent OLM from auto-upgrading past the 26.03 pin.
 
-In **Cluster Plugins**, find `kubeflow-trainer`, click **Install**, choose whether to enable `JobSet`, and complete the installation.
+In **Administrator** > **MarketPlace** > **OperatorHub**, find `kubeflow-trainer-operator`, click **Install**, choose the `Manual` install-plan approval if you need version pinning, then open the **All Instances** tab and create a `KubeflowTrainer` CR with `JobSet` enabled.

--- a/docs/en/kubeflow/install.mdx
+++ b/docs/en/kubeflow/install.mdx
@@ -3,7 +3,7 @@ weight: 20
 ---
 # Install Kubeflow Operators
 
-This page describes how to deploy Kubeflow-related operators in Alauda AI 2.0 and later.
+This page describes how to deploy Kubeflow-related operators in Alauda AI 2.3 and later.
 
 Starting in **v26.3.0** (Alauda AI v2.3), Kubeflow ships as OLM Helm Operators rather than the earlier Cluster Plugin form factor. Installation is performed from the ACP **OperatorHub** instead of **Cluster Plugins**. The operators wrap the upstream `kubeflow/manifests` 26.03 charts.
 
@@ -33,7 +33,7 @@ Before you begin, make sure the following prerequisites are met:
 
 In **Administrator** > **System Settings** > **Platform Parameters**, click **Edit** next to **Platform Access URLs** and add a redirect URL in the format `https://<your-kubeflow-domain>`, for example `https://kubeflow.example.com`.
 
-- `<your-kubeflow-domain>` must match the `kubeflowDomain` field configured in the `KubeflowBase` CR (`spec.global.kubeflowHost`).
+- `<your-kubeflow-domain>` must match `spec.global.kubeflowHost` in the `KubeflowBase` CR.
 
 ### Configure the `oauth2-proxy` Plugin
 
@@ -286,7 +286,7 @@ When creating the instance, configure the following fields as needed:
 
 > **Note:** If the deprecated `kftraining` Cluster Plugin is still installed (from a pre-v26.3.0 cluster), uninstall it before installing `kubeflow-trainer-operator`.
 >
-> **Note:** Install the LWS plugin before deploying `kubeflow-trainer-operator`, because LWS is a dependency of `kubeflow-trainer`.
+> **Note:** Install the LWS plugin before deploying `kubeflow-trainer-operator`, because LWS is a dependency of `kubeflow-trainer-operator`.
 >
 > **Note:** v26.3.0 of `kubeflow-trainer-operator` aligns with upstream `kubeflow/manifests` 26.03 and ships **Trainer v2.1.0 + JobSet v0.10.1**. For clusters where an OLM CatalogSource already advertises a higher trainer version (`>=2.2.0`), install with `installPlanApproval: Manual` and `startingCSV: kubeflow-trainer-operator.v2.1.0` to prevent OLM from auto-upgrading past the 26.03 pin.
 

--- a/docs/en/kubeflow/intro.mdx
+++ b/docs/en/kubeflow/intro.mdx
@@ -5,7 +5,7 @@ weight: 10
 
 Alauda support for Kubeflow provides a Kubernetes-native machine learning platform that enables users to build, deploy, and manage machine learning models at scale. It integrates with various components of the Kubeflow ecosystem, such as Kubeflow Pipelines for workflow orchestration, Kubeflow Trainer v2 for training job management, and Kubeflow Model Registry for model versioning and management.
 
-Starting in **v26.3.0** (Alauda AI v2.3), Alauda Kubeflow components are shipped as **OLM Helm Operators** installed from the ACP OperatorHub: `kfbase-operator`, `kfp-operator`, and `kubeflow-trainer-operator`. The earlier Cluster Plugin form factor (`v1.x`) is retired; see [Upgrade Kubeflow Plugins](./upgrade) for the migration path. The aligned upstream is [`kubeflow/manifests` release 26.03](https://github.com/kubeflow/manifests).
+Starting in **v26.3.0** (Alauda AI v2.3), Alauda Kubeflow components are shipped as **OLM Helm Operators** installed from the ACP OperatorHub: `kfbase-operator`, `kfp-operator`, and `kubeflow-trainer-operator`. The earlier Cluster Plugin form factor (`v1.x`) is retired; see [Upgrade Kubeflow Operators](./upgrade) for the migration path. The aligned upstream is [`kubeflow/manifests` release 26.03](https://github.com/kubeflow/manifests).
 
 See [Kubeflow Docs](https://www.kubeflow.org/docs/) for more details about Kubeflow components and features.
 

--- a/docs/en/kubeflow/intro.mdx
+++ b/docs/en/kubeflow/intro.mdx
@@ -3,7 +3,9 @@ weight: 10
 ---
 # Introduction
 
-Alauda support for Kubeflow provides a Kubernetes-native machine learning platform that enables users to build, deploy, and manage machine learning models at scale. It integrates with various components of the Kubeflow ecosystem, such as Kubeflow Pipelines for workflow orchestration, Kubeflow Training for training job management, and Kubeflow Model Registry for model versioning and management.
+Alauda support for Kubeflow provides a Kubernetes-native machine learning platform that enables users to build, deploy, and manage machine learning models at scale. It integrates with various components of the Kubeflow ecosystem, such as Kubeflow Pipelines for workflow orchestration, Kubeflow Trainer v2 for training job management, and Kubeflow Model Registry for model versioning and management.
+
+Starting in **v26.3.0** (Alauda AI v2.3), Alauda Kubeflow components are shipped as **OLM Helm Operators** installed from the ACP OperatorHub: `kfbase-operator`, `kfp-operator`, and `kubeflow-trainer-operator`. The earlier Cluster Plugin form factor (`v1.x`) is retired; see [Upgrade Kubeflow Plugins](./upgrade) for the migration path. The aligned upstream is [`kubeflow/manifests` release 26.03](https://github.com/kubeflow/manifests).
 
 See [Kubeflow Docs](https://www.kubeflow.org/docs/) for more details about Kubeflow components and features.
 

--- a/docs/en/kubeflow/upgrade.mdx
+++ b/docs/en/kubeflow/upgrade.mdx
@@ -19,12 +19,14 @@ Starting in **v26.3.0** (Alauda AI v2.3), Kubeflow components ship as OLM Helm O
    - Export your KFP pipelines, experiments, and scheduled runs via the `kfp` CLI.
    - Export any `TrainingRuntime` and active `TrainJob` CRs.
 2. **Uninstall the v1.x Cluster Plugin installs** from the AC UI (`Cluster Plugins`): remove `kubeflow-trainer`, `kfp`, `kftraining` (if present), and `kfbase` in that order. The matching `ModuleInfo` / `ModuleConfig` resources are removed automatically.
+
+   > **Warning:** Do not proceed until the backups in step 1 are confirmed. If uninstalling removes the `kubeflow.org` CRDs, all `Profile` CRs (and the user namespaces / Notebook PVCs they own) may be cascade-deleted. Verify whether your user namespaces and PVCs survive the uninstall before relying on the restore step below.
 3. **Install the v26.3.0 operator set** from **Administrator** > **MarketPlace** > **OperatorHub**:
    - `kfbase-operator` first (other operators depend on the base components).
    - `kfp-operator` if you need Kubeflow Pipelines (amd64 clusters only).
    - `kubeflow-trainer-operator` if you need Trainer v2.
 4. **Create the matching CR instances** (`KubeflowBase`, `KubeflowPipelines`, `KubeflowTrainer`) and reuse the configuration from your v1.x install. The chart values previously set in the Cluster Plugin install form are now exposed through the operator's CSV `specDescriptors` — most field names are unchanged.
-5. **Restore user data:** PVCs and Profile CRs reattach automatically through the Notebook controller reconcile. Re-import KFP pipelines and TrainingRuntimes.
+5. **Restore user data:** If the `Profile` CRs and their PVCs were preserved through the uninstall, they reattach automatically through the Notebook controller reconcile. If they were removed, re-apply the `Profile` CRs you exported in step 1 and restore the PVCs from your snapshots first. In all cases, re-import KFP pipelines and TrainingRuntimes.
 
 ### What changed between `v1.x` and `v26.3.0`
 

--- a/docs/en/kubeflow/upgrade.mdx
+++ b/docs/en/kubeflow/upgrade.mdx
@@ -1,13 +1,40 @@
 ---
 weight: 30
 ---
-# Upgrade Kubeflow Plugins
+# Upgrade Kubeflow Operators
 
-This page describes the manual actions that may be required after upgrading the `kfbase` plugin.
+This page describes the manual actions that may be required after upgrading the Kubeflow operators.
 
-For installation steps, see [Kubeflow Chart Plugins](./install).
+For installation steps, see [Install Kubeflow Operators](./install).
 
-## Upgrade Notes for `kfbase`
+## Migrating from `v1.x` (Cluster Plugin) to `v26.3.0` (OLM Operator)
+
+Starting in **v26.3.0** (Alauda AI v2.3), Kubeflow components ship as OLM Helm Operators (`kfbase-operator`, `kfp-operator`, `kubeflow-trainer-operator`) instead of Cluster Plugins (`kfbase`, `kfp`, `kftraining`, `kubeflow-trainer`). **There is no in-place upgrade path** between the two form factors — the Cluster Plugin install descriptor (`ModuleInfo`) and the OLM `Subscription` are mutually incompatible.
+
+### Recommended migration procedure
+
+1. **Back up user data:**
+   - Snapshot Notebook PVCs in every user namespace.
+   - Export `Profile` CRs and any custom `RoleBinding` / `AuthorizationPolicy` you created for Kubeflow users.
+   - Export your KFP pipelines, experiments, and scheduled runs via the `kfp` CLI.
+   - Export any `TrainingRuntime` and active `TrainJob` CRs.
+2. **Uninstall the v1.x Cluster Plugin installs** from the AC UI (`Cluster Plugins`): remove `kubeflow-trainer`, `kfp`, `kftraining` (if present), and `kfbase` in that order. The matching `ModuleInfo` / `ModuleConfig` resources are removed automatically.
+3. **Install the v26.3.0 operator set** from **Administrator** > **MarketPlace** > **OperatorHub**:
+   - `kfbase-operator` first (other operators depend on the base components).
+   - `kfp-operator` if you need Kubeflow Pipelines (amd64 clusters only).
+   - `kubeflow-trainer-operator` if you need Trainer v2.
+4. **Create the matching CR instances** (`KubeflowBase`, `KubeflowPipelines`, `KubeflowTrainer`) and reuse the configuration from your v1.x install. The chart values previously set in the Cluster Plugin install form are now exposed through the operator's CSV `specDescriptors` — most field names are unchanged.
+5. **Restore user data:** PVCs and Profile CRs reattach automatically through the Notebook controller reconcile. Re-import KFP pipelines and TrainingRuntimes.
+
+### What changed between `v1.x` and `v26.3.0`
+
+- **Form factor:** Cluster Plugin → OLM Helm Operator.
+- **Install descriptor:** `ModuleInfo` → OLM `Subscription` + `ClusterServiceVersion` + operator-owned CR.
+- **Trainer:** `kftraining` (Training Operator v1, deprecated) is removed; replaced by `kubeflow-trainer-operator` (Trainer v2).
+- **Upstream alignment:** all charts re-pinned to `kubeflow/manifests` 26.03.
+- **Architecture:** `kfp-operator` is now amd64-only; `kfbase-operator` and `kubeflow-trainer-operator` remain amd64 + arm64.
+
+## Upgrade Notes for `kfbase` (`v1.x` history)
 
 ### Upgrading from `v1.10.13` or earlier
 


### PR DESCRIPTION
kubeflow-plugin v26.3.0 switches from Cluster Plugin to OLM Helm Operator packaging. Update install / upgrade / intro / FAQ pages.

- intro: mention the form-factor change; reference upstream kubeflow/manifests 26.03 alignment.
- install: rewrite for the OLM OperatorHub flow. Three operators (kfbase-operator, kfp-operator, kubeflow-trainer-operator) with their owned CRs (KubeflowBase, KubeflowPipelines, KubeflowTrainer) and arch constraint (kfp-operator amd64-only). Drop deprecated kftraining Cluster Plugin step. Trainer install step now covers the OLM Manual install-plan + startingCSV pattern for clusters whose CatalogSource already advertises a higher trainer channel head.
- upgrade: new top-level migration section v1.x → v26.3.0 with backup steps, uninstall order, install order, and the explicit no-in-place-upgrade statement. Existing v1.x-history sections kept.
- faq: dual-form-factor recipe for the 'alternative platform address' case — first the v26.3.0 KubeflowBase CR path, then the legacy v1.x ModuleInfo path retained for older clusters.

Resolves kubeflow-plugin/release-materials/_release-readiness-gaps.md item B4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to reflect v26.3.0+ operator-based deployment model and OperatorHub workflows
  * Added migration guide for upgrading from legacy v1.x plugins to operators, with recommended procedure
  * Expanded FAQ with version-specific configuration and restart steps for auth proxy
  * Clarified component names, onboarding, and upgrade procedures for the new operator form factor
<!-- end of auto-generated comment: release notes by coderabbit.ai -->