### PR TITLE
docs: focus coding-agents guide on Claude Code with translation proxy

### DIFF
--- a/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
+++ b/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
@@ -10,9 +10,9 @@ i18n:
 
 ## Introduction
 
-Coding agents such as [opencode](https://opencode.ai/), [Codex CLI](https://github.com/openai/codex), and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) are terminal-based assistants that read your repository, plan changes, edit files, and run commands on your behalf. They normally talk to a hosted model provider over the internet.
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is a terminal-based coding agent that reads your repository, plans changes, edits files, and runs commands on your behalf. It normally talks to Anthropic's hosted models over the internet.
 
-This document shows how to point those agents at a model you serve yourself on Alauda AI, so that your source code, prompts, and infrastructure configuration never leave your cluster. The same on-premise `InferenceService` that you deploy for any other workload can back an interactive coding agent, as long as it exposes an **OpenAI-compatible API** and has **tool (function) calling** enabled.
+This document shows how to point Claude Code at a model you serve yourself on Alauda AI, so that your source code, prompts, and infrastructure configuration never leave your cluster. The same on-premise `InferenceService` that you deploy for any other workload can back an interactive coding agent, as long as it exposes an **OpenAI-compatible API** and has **tool (function) calling** enabled. Because Claude Code speaks the Anthropic Messages API (`/v1/messages`), you front your `InferenceService` with a lightweight translation proxy (see [Step 3](#step-3-connect-claude-code-with-a-translation-proxy)).
 
 This page builds directly on the deployment how-tos. It does not repeat how to create or expose an `InferenceService`; instead it links to them and focuses on the agent-specific configuration and tuning.
 
@@ -23,24 +23,24 @@ Coding agents and their configuration formats evolve quickly. The config snippet
 ## Prerequisites
 
 - A running, ready `InferenceService` that serves an OpenAI-compatible API. See [Create Inference Service using CLI](../model_inference/inference_service/how_to/create_inference_service_cli.mdx).
-- Network access from the machine running the agent to the service endpoint. For access from a developer laptop outside the cluster, see [Configure External Access for Inference Services](../model_inference/inference_service/how_to/external_access_inference_service.mdx).
-- A model with **tool/function calling** support, served with the matching vLLM parser enabled (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)). Without this, agents can chat but cannot edit files or run commands.
-- The agent CLI installed locally (`opencode`, `codex`, or `claude`).
+- Network access from the machine running Claude Code to the service endpoint. For access from a developer laptop outside the cluster, see [Configure External Access for Inference Services](../model_inference/inference_service/how_to/external_access_inference_service.mdx).
+- A model with **tool/function calling** support, served with the matching vLLM parser enabled (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)). Without this, the agent can chat but cannot edit files or run commands.
+- Claude Code installed locally (`claude`).
+- A translation proxy (LiteLLM or claude-code-router) to bridge Claude Code's Anthropic Messages API to the OpenAI-compatible endpoint (see [Step 3](#step-3-connect-claude-code-with-a-translation-proxy)).
 
 ## How the pieces fit together
 
 ```text
-  Coding agent (opencode / Codex / Claude Code)
-        │  OpenAI-compatible HTTP  (POST /v1/chat/completions)
+  Claude Code
+        │  Anthropic Messages API  (POST /v1/messages)
         ▼
-  External access / Load Balancer  ──►  KServe InferenceService (vLLM)
-        ▲                                       │
-        └──── Anthropic→OpenAI proxy ───────────┘
-             (only required for Claude Code)
+  Translation proxy (LiteLLM / claude-code-router)
+        │  OpenAI Chat Completions API  (POST /v1/chat/completions)
+        ▼
+  KServe InferenceService (vLLM)
 ```
 
-- **opencode** and **Codex CLI** speak the OpenAI Chat Completions API natively, so they can call the `InferenceService` endpoint directly.
-- **Claude Code** speaks the Anthropic Messages API, which vLLM does not serve. It requires a small translation proxy in front of the OpenAI-compatible endpoint (see [Claude Code](#claude-code)).
+Claude Code speaks the Anthropic Messages API (`/v1/messages`), while your `InferenceService` exposes an OpenAI-compatible endpoint (`/v1/chat/completions`). A lightweight translation proxy bridges the two.
 
 ## Step 1: Deploy and smoke-test the endpoint
 
@@ -66,6 +66,10 @@ curl -sS ${BASE_URL}/chat/completions \
 
 A normal JSON completion confirms the endpoint is reachable and the model name is correct. Note the three values you will reuse for every agent: **base URL** (ending in `/v1`), **model name** (the `--served-model-name`), and **API key**.
 
+:::tip
+For reasoning models (DeepSeek R1, QwQ, etc.), also add `--reasoning-parser` to the vLLM launch flags. See [Configure reasoning models and reasoning effort](#configure-reasoning-effort).
+:::
+
 ## Step 2: Enable tool calling on the runtime \{#enable-tool-calling-on-the-runtime}
 
 Coding agents work by calling tools (read file, write file, run shell). This requires the model to emit tool calls **and** vLLM to parse them. Add the following flags to the vLLM launch command in your `InferenceService` (in the sample from [Create Inference Service using CLI](../model_inference/inference_service/how_to/create_inference_service_cli.mdx), they go on the `python3 -m vllm.entrypoints.openai.api_server` line):
@@ -81,115 +85,192 @@ Coding agents work by calling tools (read file, write file, run shell). This req
 
 Verify tool calling end-to-end by asking the agent to perform a trivial file operation (for example, "create `hello.txt` containing the word hi"). If the model replies in prose instead of editing the file, tool calling is not wired up correctly — recheck the parser and model.
 
-## Step 3: Connect your coding agent
+## Step 2b (optional): Configure reasoning models and reasoning effort \{#configure-reasoning-effort}
 
-### opencode
+Some models (for example, DeepSeek R1, QwQ, Hunyuan, or Cohere Command A Reasoning) emit chain-of-thought reasoning before their final answer. vLLM separates the reasoning traces from the assistant content so your agent receives clean output — but you must enable the matching flags.
 
-opencode reads configuration from `opencode.json` in the project root or `~/.config/opencode/opencode.json`. Define a custom OpenAI-compatible provider that points at your endpoint:
+### Server-side flags
+
+Add `--reasoning-parser` to your vLLM launch command, paired with the appropriate tool-call parser:
+
+```bash
+--enable-auto-tool-choice \
+--tool-call-parser <parser> \
+--reasoning-parser <reasoning-parser>
+```
+
+The table below shows common model families and their required parsers. Confirm against the [vLLM tool calling documentation](https://docs.vllm.ai/en/latest/features/tool_calling.html) for the current list.
+
+| Model family | `--tool-call-parser` | `--reasoning-parser` | Notes |
+| --- | --- | --- | --- |
+| DeepSeek R1 (`deepseek-ai/DeepSeek-R1-*`) | `deepseek_v3` | *(none required)* | Also needs `--chat-template examples/tool_chat_template_deepseekr1.jinja` |
+| QwQ / Qwen reasoning (`Qwen/QwQ-*`) | `hermes` | *(none required)* | QwQ's reasoning is handled by the chat template; no separate reasoning parser needed |
+| Hunyuan-A13B-Instruct | `deepseek_v3` | `hunyuan_a13b` | Tencent's reasoning model |
+| Cohere Command A Reasoning | `cohere` | `cohere_command3` | Cohere's reasoning model |
+
+For model families not listed above, check the model card for reasoning instructions and the [vLLM tool calling documentation](https://docs.vllm.ai/en/latest/features/tool_calling.html) for the matching parser pair.
+
+### Configuring reasoning effort when starting the inference service
+
+Reasoning effort controls how much the model "thinks" before answering. For coding agents you typically want **low** reasoning effort to keep interactive latency acceptable — many short, low-reasoning turns beat a single long, high-reasoning one.
+
+#### Server-side default
+
+You can set a default reasoning effort at the vLLM server level so every request uses it unless the client overrides:
+
+```bash
+--enable-reasoning \
+--reasoning-parser <reasoning-parser> \
+--reasoning-effort low
+```
+
+`--reasoning-effort` accepts `"low"`, `"medium"` (default), or `"high"`. Setting it to `"low"` on the server ensures that even clients that don't specify reasoning effort get the responsive behavior you want for coding agents.
+
+Not all vLLM releases support `--reasoning-effort` as a launch flag. If your version doesn't recognize it, use the request-time method below.
+
+#### Request-time override
+
+DeepSeek R1 and compatible models also accept a `reasoning_effort` parameter in the request body:
 
 ```json
 {
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "onprem": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "On-Prem Alauda AI",
-      "options": {
-        "baseURL": "https://your-inference-service-domain.com/v1",
-        "apiKey": "{env:ONPREM_API_KEY}"
-      },
-      "models": {
-        "qwen-2": {
-          "name": "Qwen2.5-Coder (on-prem)"
-        }
-      }
-    }
+  "model": "deepseek-r1",
+  "messages": [{"role": "user", "content": "..."}],
+  "extra_body": {
+    "reasoning_effort": "low"
   }
 }
 ```
 
-- The model key (`qwen-2`) must match the `--served-model-name` of the `InferenceService`.
-- Export the key the config references, then select the model: `export ONPREM_API_KEY=sk-local` and choose `onprem/qwen-2` with the `/models` command inside opencode.
+When using a translation proxy (LiteLLM or claude-code-router), the proxy forwards this parameter to the backend automatically.
 
-### Codex CLI
+**Note:** Qwen reasoning models (QwQ) do not have a separate reasoning-effort knob. Control reasoning depth indirectly through the chat template or by passing `max_tokens` to cap how long the reasoning chain can grow.
 
-Codex CLI reads `~/.codex/config.toml`. Register your endpoint as a model provider and select it:
+## Step 3: Connect Claude Code with a Translation Proxy \{#step-3-connect-claude-code-with-a-translation-proxy}
 
-```toml
-model = "qwen-2"
-model_provider = "onprem"
-
-[model_providers.onprem]
-name = "On-Prem Alauda AI"
-base_url = "https://your-inference-service-domain.com/v1"
-env_key = "ONPREM_API_KEY"
-wire_api = "chat"
-```
-
-- `base_url` must end at `/v1`; `model` must match the `--served-model-name`.
-- `env_key` names the environment variable that holds the API key: `export ONPREM_API_KEY=sk-local`.
-- Use `wire_api = "chat"` for vLLM's OpenAI Chat Completions API.
-
-### Claude Code \{#claude-code}
-
-Claude Code communicates over the Anthropic Messages API (`/v1/messages`). There are two ways to back it with an on-premise model — pick the one that matches your runtime.
-
-#### Option A: point Claude Code directly at the on-premise endpoint
-
-If the on-premise endpoint already speaks the Anthropic Messages API — either natively (for example, some `llama.cpp` `llama-server` builds and similar local runners) or because you front your `InferenceService` with a gateway that exposes `/v1/messages` — you can configure Claude Code with environment variables alone, no separate proxy needed:
-
-```bash
-export ANTHROPIC_BASE_URL="http://127.0.0.1:9123"      # on-premise endpoint speaking the Anthropic Messages API
-export ANTHROPIC_AUTH_TOKEN="not_set"                  # any value; the endpoint may ignore it
-export ANTHROPIC_API_KEY="not_set_either!"             # any value; both vars are checked
-export ANTHROPIC_MODEL="qwen-2"                        # must match what the endpoint exposes (e.g. served-model-name)
-
-# Keep traffic on-premise and trim features the on-prem model can't honor:
-export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1      # suppress optional traffic to Anthropic-hosted services
-export CLAUDE_CODE_ATTRIBUTION_HEADER=0                # drop the Anthropic attribution header
-export CLAUDE_CODE_ENABLE_TELEMETRY=0                  # disable telemetry
-export CLAUDE_CODE_DISABLE_1M_CONTEXT=1                # disable the 1M-context feature; most on-prem models can't serve it
-export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000             # cap to what the on-prem model and runtime support
-
-claude
-```
-
-A few notes on the values:
-
-- The `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` values must be non-empty but their content does not matter if your endpoint does not check them; gate access at the endpoint or in front of it (see [Manage gateways](./mlops-with-coding-agents.mdx#manage-gateways) for adding auth via Envoy AI Gateway).
-- `ANTHROPIC_MODEL` must match the model name the endpoint exposes (the `--served-model-name` from your `InferenceService`, or whatever your local runner advertises).
-- The `CLAUDE_CODE_DISABLE_*` and `CLAUDE_CODE_*=0` flags are what actually keep an "on-prem" setup on-prem: without them, Claude Code can still emit non-essential requests to Anthropic-hosted endpoints and ask the model for features (1M context, very large outputs) the on-prem model cannot honor.
-
-#### Option B: front an OpenAI-compatible endpoint with a translation proxy
-
-If your endpoint is OpenAI-compatible only (for example, a stock vLLM `InferenceService` exposing `/v1/chat/completions` but not `/v1/messages`), run a small gateway that accepts Anthropic-format requests and forwards them. Two common options:
+Claude Code communicates over the Anthropic Messages API (`/v1/messages`), while your `InferenceService` exposes an OpenAI-compatible endpoint (`/v1/chat/completions`). Bridge the two by running a translation proxy in front of your endpoint. Two common options:
 
 - [LiteLLM](https://docs.litellm.ai/) proxy, which exposes an Anthropic-compatible `/v1/messages` endpoint and routes to any backend model.
 - [claude-code-router](https://github.com/musistudio/claude-code-router), a proxy built specifically to point Claude Code at OpenAI-compatible and other backends.
 
-Then use the same env-var configuration from Option A, with `ANTHROPIC_BASE_URL` pointing at the proxy and `ANTHROPIC_MODEL` set to the model alias the proxy exposes. Optionally also set `ANTHROPIC_SMALL_FAST_MODEL` to an on-prem model so background/low-cost requests stay on-prem too.
+Both approaches handle the API translation for you. Pick whichever fits your workflow — LiteLLM is more general-purpose, while claude-code-router is tailored to Claude Code's needs.
 
-Regardless of which option you pick, Claude Code's agentic quality depends heavily on the served model's tool-calling fidelity — prefer a strong instruction- and tool-tuned model, and confirm tool calls round-trip end-to-end before relying on it.
+### Option 1: LiteLLM proxy
+
+Start the LiteLLM proxy, pointing it at your `InferenceService` endpoint:
+
+```bash
+litellm --model openai/qwen-2 \
+  --api_base https://your-inference-service-domain.com/v1 \
+  --port 4000
+```
+
+This exposes `http://localhost:4000/v1/messages` (Anthropic format) and forwards requests to your OpenAI-compatible backend.
+
+Then point Claude Code at the proxy:
+
+```bash
+export ANTHROPIC_BASE_URL="http://127.0.0.1:4000"
+export ANTHROPIC_AUTH_TOKEN="not_set"
+export ANTHROPIC_API_KEY="not_set_either!"
+export ANTHROPIC_MODEL="qwen-2"
+
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+export CLAUDE_CODE_ATTRIBUTION_HEADER=0
+export CLAUDE_CODE_ENABLE_TELEMETRY=0
+export CLAUDE_CODE_DISABLE_1M_CONTEXT=1
+export CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
+
+claude
+```
+
+### Option 2: claude-code-router
+
+Create a config file at `~/.claude-code-router/config.json` with your `InferenceService` as a provider:
+
+```json
+{
+  "Providers": [
+    {
+      "name": "onprem",
+      "api_base_url": "https://your-inference-service-domain.com/v1/chat/completions",
+      "api_key": "sk-local",
+      "models": ["qwen-2"]
+    }
+  ],
+  "Router": {
+    "default": "onprem,qwen-2"
+  }
+}
+```
+
+Then start Claude Code through the router:
+
+```bash
+ccr code
+```
+
+The router automatically sets the required `ANTHROPIC_BASE_URL` and other environment variables — no manual `export` needed. The model is selected by the `Router.default` field in the config (format: `provider_name,model_name`). You can also activate the router in your shell first with `eval "$(ccr activate)"` and then run `claude` directly. Inside a running session, switch models with `/model provider_name,model_name`.
+
+### Notes for on-premise operation
+
+- The `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` values (used with the LiteLLM option) must be non-empty but their content does not matter if your proxy and endpoint do not check them; gate access at the endpoint or proxy (see [Manage gateways](./mlops-with-coding-agents.mdx#manage-gateways) for adding auth via Envoy AI Gateway).
+- The `CLAUDE_CODE_DISABLE_*` flags are what actually keep an "on-prem" setup on-prem: without them, Claude Code can still emit non-essential requests to Anthropic-hosted endpoints and ask the model for features (1M context, very large outputs) the on-prem model cannot honor. claude-code-router sets some of these automatically.
+- `ANTHROPIC_MODEL` must match the model name your `InferenceService` exposes (the `--served-model-name`).
+- Optionally set `ANTHROPIC_SMALL_FAST_MODEL` to an on-prem model so background/low-cost requests stay on-prem too.
+
+Claude Code's agentic quality depends heavily on the served model's tool-calling fidelity — prefer a strong instruction- and tool-tuned model, and confirm tool calls round-trip end-to-end before relying on it.
 
 ## Best practices \{#best-practices}
+
+### Recommended model families for coding agents
+
+**Qwen3.6** and **Gemma 4** are the two model families we currently recommend for on-premise coding agents. Both have strong tool-calling support, mature vLLM parsers, and a wide range of sizes and quantization formats available.
+
+| Family | Why it works for coding agents | vLLM `--tool-call-parser` |
+| --- | --- | --- |
+| **Qwen3.6** (Qwen team) | Strong code generation, instruction following, and tool calling. MoE variants (35B-A3B) activate only ~3B parameters per token, giving high throughput at low VRAM cost. | `hermes` |
+| **Gemma 4** (Google) | Clean instruction tuning, compact sizes (E2B, E4B) that fit on consumer GPUs. Verify tool-calling support in the vLLM version you run; Gemma's parser assignment may vary by vLLM release. | Check [vLLM tool calling docs](https://docs.vllm.ai/en/latest/features/tool_calling.html) |
+| **Qwen3-Coder** (Qwen team) | Code-specialized; the MoE variants (30B-A3B, 480B-A35B) are powerful but require more hardware. | `hermes` |
 
 ### Choose a model that fits your hardware
 
 Start from the GPU memory you have, then pick the largest capable model that leaves headroom for the KV cache. A rough weight-size estimate is `parameters × bytes-per-parameter` — FP16 ≈ 2 bytes, FP8/INT8 ≈ 1 byte, INT4 ≈ 0.5 bytes per parameter — on top of which the KV cache and runtime overhead consume more memory. Leave **15–25% headroom**.
 
-| GPU memory (single GPU) | Example GPUs | Practical coding-model choices |
+#### Quantized models from Unsloth on HuggingFace
+
+[Unsloth](https://huggingface.co/unsloth) publishes GGUF-quantized versions of the latest models, optimized for fast loading with vLLM. The table below lists the most useful ones for coding agents:
+
+| Model | Format | Active params | VRAM (approx.) | Notes |
+| --- | --- | --- | --- | --- |
+| [`unsloth/gemma-4-E2B-it-qat-GGUF`](https://huggingface.co/unsloth/gemma-4-E2B-it-qat-GGUF) | GGUF (QAT) | 2B | ~4 GB | Fastest option; fits on any GPU |
+| [`unsloth/gemma-4-E4B-it-qat-GGUF`](https://huggingface.co/unsloth/gemma-4-E4B-it-qat-GGUF) | GGUF (QAT) | 4B | ~8 GB | Strong tool-calling at low cost |
+| [`unsloth/gemma-4-12b-it-GGUF`](https://huggingface.co/unsloth/gemma-4-12b-it-GGUF) | GGUF | 12B | ~16 GB | Good balance of speed and quality |
+| [`unsloth/gemma-4-26B-A4B-it-GGUF`](https://huggingface.co/unsloth/gemma-4-26B-A4B-it-GGUF) | GGUF (MoE) | 4B active | ~12 GB | MoE: high quality, low active VRAM |
+| [`unsloth/gemma-4-31B-it-GGUF`](https://huggingface.co/unsloth/gemma-4-31B-it-GGUF) | GGUF | 31B | ~40 GB | Largest Gemma 4 dense model |
+| [`unsloth/Qwen3.6-27B-GGUF`](https://huggingface.co/unsloth/Qwen3.6-27B-GGUF) | GGUF | 27B | ~36 GB | Strong general-purpose coding |
+| [`unsloth/Qwen3.6-27B-MTP-GGUF`](https://huggingface.co/unsloth/Qwen3.6-27B-MTP-GGUF) | GGUF (MTP) | 27B | ~36 GB | Multi-token prediction for faster decode |
+| [`unsloth/Qwen3.6-35B-A3B-MTP-GGUF`](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-MTP-GGUF) | GGUF (MoE+MTP) | 3B active | ~12 GB | Best quality/cost ratio; MoE + MTP |
+
+> **Note:** GGUF-quantized models load in vLLM via `--quantization gguf`. For AWQ or GPTQ INT4 variants, check [huggingface.co/models](https://huggingface.co/models?sort=trending&search=AWQ) — search for `qwen3.6 AWQ` or `gemma-4 GPTQ` to find community-quantized versions. Unsloth's QAT (quantization-aware training) models typically retain higher quality at aggressive bit-widths than post-hoc quantization.
+
+#### Hardware fit guide
+
+| GPU memory (single GPU) | Example GPUs | Recommended model |
 | --- | --- | --- |
-| 16–24 GB | L4, A10, A30 (24G), RTX 4090 | 7–8B at FP16, or 14B quantized (AWQ/GPTQ INT4) |
-| 40–48 GB | A40, L40S, A6000, A100-40G | 14B at FP16, or 32B quantized (AWQ/GPTQ INT4) |
-| 80 GB | A100-80G, H100, H800 | 32B at FP16, or 70B at INT4 / FP8 |
-| Multi-GPU (2–8×) | 2–8 × 80 GB | 70B+ at FP16 with tensor parallel, or large MoE models |
+| 8–16 GB | L4, A10, RTX 4070 | `gemma-4-E2B` or `gemma-4-E4B` (QAT GGUF) |
+| 16–24 GB | A30 (24G), RTX 4090 | `gemma-4-12B` or `Qwen3.6-35B-A3B` (MoE, 3B active) |
+| 40–48 GB | A40, L40S, A6000 | `Qwen3.6-27B` or `gemma-4-31B` (GGUF) |
+| 80 GB | A100-80G, H100, H800 | `Qwen3.6-27B` at FP16, or `gemma-4-31B` at FP16 |
+| Multi-GPU (2–8×) | 2–8 × 80 GB | `Qwen3-Coder-480B-A35B` (MoE, tensor-parallel) |
 
 Additional selection guidance:
 
 - **Prefer code-specialized, instruction-tuned models** that natively support tool/function calling. If the model card does not mention tool calling, the agent will not be able to edit files reliably.
-- **Confirm a matching vLLM parser exists** for the model (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)) before committing to it.
+- **Confirm a matching vLLM parser exists** for the model (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)) before committing to it. Qwen3.6 models use `hermes`; verify Gemma 4's parser in the vLLM docs for your version.
 - **Budget for context length.** Coding agents send large prompts (system prompt + file and repo context). Pick a model whose context window covers your largest expected prompt, and remember that a longer `--max-model-len` consumes more KV cache per request, reducing concurrency.
-- **Quantization is a force multiplier on-premise.** INT4 (AWQ/GPTQ) or FP8 lets you fit a noticeably more capable model in the same VRAM, which usually matters more for agent quality than raw FP16 precision.
+- **Quantization is a force multiplier on-premise.** INT4 (AWQ/GPTQ) or GGUF quantization lets you fit a noticeably more capable model in the same VRAM, which usually matters more for agent quality than raw FP16 precision.
+- **MoE models are especially efficient.** Qwen3.6-35B-A3B and Gemma 4-26B-A4B activate only 3–4B parameters per token while carrying a larger knowledge base, giving near-dense quality at a fraction of the VRAM cost.
 
 ### Tune inference service performance
 
@@ -211,7 +292,7 @@ Coding-agent traffic has a distinctive shape: long, highly repetitive prompts (t
 
 "Vibe coding" — iterating quickly by describing intent and letting the agent write the code — works well with a self-hosted model once the basics are right:
 
-1. Start with a 7–14B code model that fits comfortably on your GPU with headroom; a responsive smaller model beats a sluggish larger one for interactive flow.
+1. Start with a Qwen3.6 or Gemma 4 model that fits comfortably on your GPU with headroom; a responsive smaller model beats a sluggish larger one for interactive flow. For 24 GB GPUs, `Qwen3.6-35B-A3B` (MoE) is an excellent starting point.
 2. Set a **low temperature** (around `0–0.2`) for code generation to keep edits deterministic and reduce flailing.
 3. Validate tool calling with one trivial task ("create a file and run it") before attempting anything real.
 4. Keep prompts focused — open or reference only the relevant files so the agent's context stays on-topic and prefill stays cheap.
@@ -226,6 +307,8 @@ Because the model runs inside your cluster, a coding agent backed by an on-premi
 - Author and adjust pipelines and monitoring for your model lifecycle.
 - Close the loop: deploy a model with the agent, then use that same on-premise model to drive further platform operations.
 
+For detailed MLOps workflows — managing InferenceServices, configuring gateways, tuning performance iteratively, and planning fine-tuning runs — see [Run MLOps with Coding Agents and On-Premise LLMs](./mlops-with-coding-agents.mdx).
+
 ## Troubleshooting
 
 - **Agent chats but never edits files or runs commands.** Tool calling is not enabled or the parser does not match the model — see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime).
@@ -236,6 +319,7 @@ Because the model runs inside your cluster, a coding agent backed by an on-premi
 
 ## References
 
+- [Run MLOps with Coding Agents and On-Premise LLMs](./mlops-with-coding-agents.mdx)
 - [Create Inference Service using CLI](../model_inference/inference_service/how_to/create_inference_service_cli.mdx)
 - [Configure External Access for Inference Services](../model_inference/inference_service/how_to/external_access_inference_service.mdx)
 - [Configure Scaling for Inference Services](../model_inference/inference_service/how_to/autoscale_settings.mdx)
@@ -244,8 +328,6 @@ Because the model runs inside your cluster, a coding agent backed by an on-premi
 - [Extend Inference Runtimes](../model_inference/inference_service/how_to/custom_inference_runtime.mdx)
 - [Tool Calling — vLLM](https://docs.vllm.ai/en/latest/features/tool_calling.html)
 - [Automatic Prefix Caching — vLLM](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html)
-- [opencode documentation](https://opencode.ai/docs/)
-- [Codex CLI](https://github.com/openai/codex)
 - [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
 - [LiteLLM](https://docs.litellm.ai/)
 - [claude-code-router](https://github.com/musistudio/claude-code-router)

--- a/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
+++ b/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
@@ -123,27 +123,31 @@ Reasoning effort controls how much the model "thinks" before answering. For codi
 
 #### Server-side defaults
 
-vLLM does not expose a generic `--reasoning-effort` launch flag. Server-wide control is achieved through the model's chat template — you can supply a custom Jinja template that disables thinking by default, then pass it with `--chat-template`. Alternatively, some models and vLLM versions expose per-model template kwargs; check the vLLM release notes for the specific key. For a quick start, request-level parameters (see below) are the most portable approach.
+vLLM does not expose a generic `--reasoning-effort` launch flag. Server-wide control is achieved through the model's chat template: you can supply a custom Jinja template that disables thinking by default, then pass it with `--chat-template`. Alternatively, some models and vLLM versions expose per-model template kwargs; check the vLLM release notes for the specific key.
 
-#### Request-time override
+#### Request-time controls
 
-Models that support OpenAI-style reasoning effort accept `reasoning_effort` as a top-level request parameter:
+Do not assume every vLLM-backed `InferenceService` accepts `reasoning_effort`. Support depends on the vLLM version, OpenAI-compatible server implementation, model, and chat template. If the service rejects unknown request fields, `reasoning_effort` can fail even when the model itself supports reasoning.
+
+Prefer model-specific controls that your deployed vLLM service documents. For example, Qwen3-style templates commonly use `chat_template_kwargs` to enable or disable thinking:
 
 ```json
 {
-  "model": "google/gemma-4-26B-A4B-it",
+  "model": "Qwen/Qwen3-8B",
   "messages": [{"role": "user", "content": "..."}],
-  "reasoning_effort": "low"
+  "chat_template_kwargs": {
+    "enable_thinking": false
+  }
 }
 ```
 
-When using the OpenAI Python client, pass it as a normal argument:
+When using the OpenAI Python client, pass vLLM-specific request fields through `extra_body`:
 
 ```python
 client.chat.completions.create(
-    model="google/gemma-4-26B-A4B-it",
+    model="Qwen/Qwen3-8B",
     messages=[{"role": "user", "content": "..."}],
-    reasoning_effort="low",
+    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
 )
 ```
 
@@ -159,7 +163,7 @@ For parsers that support an explicit thinking budget, you can also cap reasoning
 
 When using a translation proxy (LiteLLM or claude-code-router), confirm the proxy version passes through these vLLM/OpenAI extension fields before relying on them.
 
-**Note:** QwQ and Qwen3-style reasoning do not use `reasoning_effort` for a simple low/medium/high knob. Control their behavior with `chat_template_kwargs`, `thinking_token_budget`, or `max_tokens`, depending on what your model and vLLM version support.
+Only use `reasoning_effort` after you verify that your exact vLLM image and model template accept it. On supported deployments, it can be sent as a top-level Chat Completions field such as `"reasoning_effort": "low"`; on unsupported deployments, use `chat_template_kwargs`, `thinking_token_budget`, or `max_tokens` instead.
 
 ## Step 3: Connect your coding agent
 

--- a/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
+++ b/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
@@ -10,9 +10,9 @@ i18n:
 
 ## Introduction
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) is a terminal-based coding agent that reads your repository, plans changes, edits files, and runs commands on your behalf. It normally talks to Anthropic's hosted models over the internet.
+Coding agents such as [opencode](https://opencode.ai/), [Codex CLI](https://github.com/openai/codex), and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) are terminal-based assistants that read your repository, plan changes, edit files, and run commands on your behalf. They normally talk to a hosted model provider over the internet.
 
-This document shows how to point Claude Code at a model you serve yourself on Alauda AI, so that your source code, prompts, and infrastructure configuration never leave your cluster. The same on-premise `InferenceService` that you deploy for any other workload can back an interactive coding agent, as long as it exposes an **OpenAI-compatible API** and has **tool (function) calling** enabled. Because Claude Code speaks the Anthropic Messages API (`/v1/messages`), you front your `InferenceService` with a lightweight translation proxy (see [Step 3](#step-3-connect-claude-code-with-a-translation-proxy)).
+This document shows how to point those agents at a model you serve yourself on Alauda AI, so that your source code, prompts, and infrastructure configuration never leave your cluster. The same on-premise `InferenceService` that you deploy for any other workload can back an interactive coding agent, as long as it exposes an **OpenAI-compatible API** and has **tool (function) calling** enabled. opencode and Codex CLI can call that endpoint directly; Claude Code speaks the Anthropic Messages API (`/v1/messages`) and needs a lightweight translation proxy (see [Claude Code](#claude-code)).
 
 This page builds directly on the deployment how-tos. It does not repeat how to create or expose an `InferenceService`; instead it links to them and focuses on the agent-specific configuration and tuning.
 
@@ -23,24 +23,30 @@ Coding agents and their configuration formats evolve quickly. The config snippet
 ## Prerequisites
 
 - A running, ready `InferenceService` that serves an OpenAI-compatible API. See [Create Inference Service using CLI](../model_inference/inference_service/how_to/create_inference_service_cli.mdx).
-- Network access from the machine running Claude Code to the service endpoint. For access from a developer laptop outside the cluster, see [Configure External Access for Inference Services](../model_inference/inference_service/how_to/external_access_inference_service.mdx).
-- A model with **tool/function calling** support, served with the matching vLLM parser enabled (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)). Without this, the agent can chat but cannot edit files or run commands.
-- Claude Code installed locally (`claude`).
-- A translation proxy (LiteLLM or claude-code-router) to bridge Claude Code's Anthropic Messages API to the OpenAI-compatible endpoint (see [Step 3](#step-3-connect-claude-code-with-a-translation-proxy)).
+- Network access from the machine running the agent to the service endpoint. For access from a developer laptop outside the cluster, see [Configure External Access for Inference Services](../model_inference/inference_service/how_to/external_access_inference_service.mdx).
+- A model with **tool/function calling** support, served with the matching vLLM parser enabled (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)). Without this, agents can chat but cannot edit files or run commands.
+- The agent CLI installed locally (`opencode`, `codex`, or `claude`).
+- For Claude Code, a translation proxy (LiteLLM or claude-code-router) to bridge Claude Code's Anthropic Messages API to the OpenAI-compatible endpoint (see [Claude Code](#claude-code)).
 
 ## How the pieces fit together
 
 ```text
+  opencode / Codex CLI
+        │  OpenAI Chat Completions API  (POST /v1/chat/completions)
+        ▼
+  External access / Load Balancer  ──►  KServe InferenceService (vLLM)
+
   Claude Code
         │  Anthropic Messages API  (POST /v1/messages)
         ▼
   Translation proxy (LiteLLM / claude-code-router)
         │  OpenAI Chat Completions API  (POST /v1/chat/completions)
         ▼
-  KServe InferenceService (vLLM)
+  same InferenceService endpoint
 ```
 
-Claude Code speaks the Anthropic Messages API (`/v1/messages`), while your `InferenceService` exposes an OpenAI-compatible endpoint (`/v1/chat/completions`). A lightweight translation proxy bridges the two.
+- **opencode** and **Codex CLI** speak the OpenAI Chat Completions API natively, so they can call the `InferenceService` endpoint directly.
+- **Claude Code** speaks the Anthropic Messages API, which vLLM does not serve. It requires a small translation proxy in front of the OpenAI-compatible endpoint (see [Claude Code](#claude-code)).
 
 ## Step 1: Deploy and smoke-test the endpoint
 
@@ -67,7 +73,7 @@ curl -sS ${BASE_URL}/chat/completions \
 A normal JSON completion confirms the endpoint is reachable and the model name is correct. Note the three values you will reuse for every agent: **base URL** (ending in `/v1`), **model name** (the `--served-model-name`), and **API key**.
 
 :::tip
-For reasoning models (DeepSeek R1, QwQ, etc.), also add `--reasoning-parser` to the vLLM launch flags. See [Configure reasoning models and reasoning effort](#configure-reasoning-effort).
+For reasoning models (DeepSeek R1, QwQ, Qwen3, etc.), also add the matching `--reasoning-parser` to the vLLM launch flags. See [Configure reasoning models and reasoning effort](#configure-reasoning-effort).
 :::
 
 ## Step 2: Enable tool calling on the runtime \{#enable-tool-calling-on-the-runtime}
@@ -79,7 +85,7 @@ Coding agents work by calling tools (read file, write file, run shell). This req
 --tool-call-parser hermes        # match the parser to your model family
 ```
 
-- The parser must match the model. For example, Qwen2.5 / Qwen3 family models commonly use `hermes`; Llama 3.x models use `llama3_json`; Mistral models use `mistral`. Check the [vLLM tool calling documentation](https://docs.vllm.ai/en/latest/features/tool_calling.html) for the current parser list and the value that matches your model.
+- The parser must match the model. For example, Qwen2.5 and QwQ-32B commonly use `hermes`; Qwen3-Coder uses `qwen3_xml`; Llama 3.x models use `llama3_json`; Mistral models use `mistral`. Check the [vLLM tool calling documentation](https://docs.vllm.ai/en/latest/features/tool_calling.html) for the current parser list and the value that matches your model.
 - Some models need a specific chat template to emit tool calls correctly; pass `--chat-template` if the model card calls for it.
 - If you serve a reasoning model, also enable the matching `--reasoning-parser` so the agent receives clean assistant content separated from reasoning traces.
 
@@ -91,7 +97,7 @@ Some models (for example, DeepSeek R1, QwQ, Hunyuan, or Cohere Command A Reasoni
 
 ### Server-side flags
 
-Add `--reasoning-parser` to your vLLM launch command, paired with the appropriate tool-call parser:
+Add `--reasoning-parser` to your vLLM launch command. If the same model also needs agent tool calls, pair it with the appropriate `--tool-call-parser`:
 
 ```bash
 --enable-auto-tool-choice \
@@ -103,50 +109,115 @@ The table below shows common model families and their required parsers. Confirm 
 
 | Model family | `--tool-call-parser` | `--reasoning-parser` | Notes |
 | --- | --- | --- | --- |
-| DeepSeek R1 (`deepseek-ai/DeepSeek-R1-*`) | `deepseek_v3` | *(none required)* | Also needs `--chat-template examples/tool_chat_template_deepseekr1.jinja` |
-| QwQ / Qwen reasoning (`Qwen/QwQ-*`) | `hermes` | *(none required)* | QwQ's reasoning is handled by the chat template; no separate reasoning parser needed |
-| Hunyuan-A13B-Instruct | `deepseek_v3` | `hunyuan_a13b` | Tencent's reasoning model |
-| Cohere Command A Reasoning | `cohere` | `cohere_command3` | Cohere's reasoning model |
+| DeepSeek R1 (`deepseek-ai/DeepSeek-R1-*`) | `deepseek_v3` for DeepSeek-R1 tool calling | `deepseek_r1` | DeepSeek-R1-0528 tool calling also needs `--chat-template examples/tool_chat_template_deepseekr1.jinja` |
+| QwQ (`Qwen/QwQ-32B`) | `hermes` | `deepseek_r1` | QwQ uses Hermes-style tool calls and DeepSeek-style reasoning tags |
+| Qwen3 reasoning (`Qwen/Qwen3-*`) | Check the current vLLM docs for the exact Qwen variant | `qwen3` | Qwen3 reasoning is enabled by default; disable it with `chat_template_kwargs` if needed |
+| Hunyuan-A13B-Instruct | `hunyuan_a13b` | `hunyuan_a13b` | Use both parsers when serving the reasoning mode with tool calls |
+| Cohere Command A Reasoning | `cohere_command3` | `cohere_command3` | Requires the optional `cohere_melody` package |
 
 For model families not listed above, check the model card for reasoning instructions and the [vLLM tool calling documentation](https://docs.vllm.ai/en/latest/features/tool_calling.html) for the matching parser pair.
 
-### Configuring reasoning effort when starting the inference service
+### Configuring reasoning effort and thinking behavior
 
 Reasoning effort controls how much the model "thinks" before answering. For coding agents you typically want **low** reasoning effort to keep interactive latency acceptable — many short, low-reasoning turns beat a single long, high-reasoning one.
 
-#### Server-side default
+#### Server-side defaults
 
-You can set a default reasoning effort at the vLLM server level so every request uses it unless the client overrides:
+vLLM does not expose a generic `--reasoning-effort` launch flag. For server-wide defaults, configure the model's chat-template thinking knobs instead. For example, Qwen3 enables thinking by default, so you can disable it server-wide:
 
 ```bash
---enable-reasoning \
---reasoning-parser <reasoning-parser> \
---reasoning-effort low
+--reasoning-parser qwen3 \
+--default-chat-template-kwargs '{"enable_thinking": false}'
 ```
 
-`--reasoning-effort` accepts `"low"`, `"medium"` (default), or `"high"`. Setting it to `"low"` on the server ensures that even clients that don't specify reasoning effort get the responsive behavior you want for coding agents.
-
-Not all vLLM releases support `--reasoning-effort` as a launch flag. If your version doesn't recognize it, use the request-time method below.
+For models whose templates expose a different thinking switch, use the key documented by the model or vLLM. Request-level `chat_template_kwargs` override the server default.
 
 #### Request-time override
 
-DeepSeek R1 and compatible models also accept a `reasoning_effort` parameter in the request body:
+Models that support OpenAI-style reasoning effort accept `reasoning_effort` as a top-level request parameter:
 
 ```json
 {
-  "model": "deepseek-r1",
+  "model": "google/gemma-4-26B-A4B-it",
   "messages": [{"role": "user", "content": "..."}],
-  "extra_body": {
-    "reasoning_effort": "low"
+  "reasoning_effort": "low"
+}
+```
+
+When using the OpenAI Python client, pass it as a normal argument:
+
+```python
+client.chat.completions.create(
+    model="google/gemma-4-26B-A4B-it",
+    messages=[{"role": "user", "content": "..."}],
+    reasoning_effort="low",
+)
+```
+
+For parsers that support an explicit thinking budget, you can also cap reasoning tokens per request:
+
+```json
+{
+  "model": "Qwen/Qwen3-0.6B",
+  "messages": [{"role": "user", "content": "..."}],
+  "thinking_token_budget": 256
+}
+```
+
+When using a translation proxy (LiteLLM or claude-code-router), confirm the proxy version passes through these vLLM/OpenAI extension fields before relying on them.
+
+**Note:** QwQ and Qwen3-style reasoning do not use `reasoning_effort` for a simple low/medium/high knob. Control their behavior with `chat_template_kwargs`, `thinking_token_budget`, or `max_tokens`, depending on what your model and vLLM version support.
+
+## Step 3: Connect your coding agent
+
+### opencode
+
+opencode reads configuration from `opencode.json` in the project root or `~/.config/opencode/opencode.json`. Define a custom OpenAI-compatible provider that points at your endpoint:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "onprem": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "On-Prem Alauda AI",
+      "options": {
+        "baseURL": "https://your-inference-service-domain.com/v1",
+        "apiKey": "{env:ONPREM_API_KEY}"
+      },
+      "models": {
+        "qwen-2": {
+          "name": "Qwen2.5-Coder (on-prem)"
+        }
+      }
+    }
   }
 }
 ```
 
-When using a translation proxy (LiteLLM or claude-code-router), the proxy forwards this parameter to the backend automatically.
+- The model key (`qwen-2`) must match the `--served-model-name` of the `InferenceService`.
+- Export the key the config references, then select the model: `export ONPREM_API_KEY=sk-local` and choose `onprem/qwen-2` with the `/models` command inside opencode.
 
-**Note:** Qwen reasoning models (QwQ) do not have a separate reasoning-effort knob. Control reasoning depth indirectly through the chat template or by passing `max_tokens` to cap how long the reasoning chain can grow.
+### Codex CLI
 
-## Step 3: Connect Claude Code with a Translation Proxy \{#step-3-connect-claude-code-with-a-translation-proxy}
+Codex CLI reads `~/.codex/config.toml`. Register your endpoint as a model provider and select it:
+
+```toml
+model = "qwen-2"
+model_provider = "onprem"
+
+[model_providers.onprem]
+name = "On-Prem Alauda AI"
+base_url = "https://your-inference-service-domain.com/v1"
+env_key = "ONPREM_API_KEY"
+wire_api = "chat"
+```
+
+- `base_url` must end at `/v1`; `model` must match the `--served-model-name`.
+- `env_key` names the environment variable that holds the API key: `export ONPREM_API_KEY=sk-local`.
+- Use `wire_api = "chat"` for vLLM's OpenAI Chat Completions API.
+
+### Claude Code \{#claude-code}
 
 Claude Code communicates over the Anthropic Messages API (`/v1/messages`), while your `InferenceService` exposes an OpenAI-compatible endpoint (`/v1/chat/completions`). Bridge the two by running a translation proxy in front of your endpoint. Two common options:
 
@@ -225,13 +296,13 @@ Claude Code's agentic quality depends heavily on the served model's tool-calling
 
 ### Recommended model families for coding agents
 
-**Qwen3.6** and **Gemma 4** are the two model families we currently recommend for on-premise coding agents. Both have strong tool-calling support, mature vLLM parsers, and a wide range of sizes and quantization formats available.
+**Qwen3.6** and **Gemma 4** are the two model families we currently recommend for on-premise coding agents. Both have strong instruction tuning and a wide range of sizes and quantization formats available; verify tool-calling parser support against the vLLM version you run.
 
 | Family | Why it works for coding agents | vLLM `--tool-call-parser` |
 | --- | --- | --- |
-| **Qwen3.6** (Qwen team) | Strong code generation, instruction following, and tool calling. MoE variants (35B-A3B) activate only ~3B parameters per token, giving high throughput at low VRAM cost. | `hermes` |
+| **Qwen3.6** (Qwen team) | Strong code generation and instruction following. MoE variants (35B-A3B) activate only ~3B parameters per token, giving high throughput at low VRAM cost. | Check [vLLM tool calling docs](https://docs.vllm.ai/en/latest/features/tool_calling.html) |
 | **Gemma 4** (Google) | Clean instruction tuning, compact sizes (E2B, E4B) that fit on consumer GPUs. Verify tool-calling support in the vLLM version you run; Gemma's parser assignment may vary by vLLM release. | Check [vLLM tool calling docs](https://docs.vllm.ai/en/latest/features/tool_calling.html) |
-| **Qwen3-Coder** (Qwen team) | Code-specialized; the MoE variants (30B-A3B, 480B-A35B) are powerful but require more hardware. | `hermes` |
+| **Qwen3-Coder** (Qwen team) | Code-specialized; the MoE variants (30B-A3B, 480B-A35B) are powerful but require more hardware. | `qwen3_xml` |
 
 ### Choose a model that fits your hardware
 
@@ -267,7 +338,7 @@ Start from the GPU memory you have, then pick the largest capable model that lea
 Additional selection guidance:
 
 - **Prefer code-specialized, instruction-tuned models** that natively support tool/function calling. If the model card does not mention tool calling, the agent will not be able to edit files reliably.
-- **Confirm a matching vLLM parser exists** for the model (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)) before committing to it. Qwen3.6 models use `hermes`; verify Gemma 4's parser in the vLLM docs for your version.
+- **Confirm a matching vLLM parser exists** for the model (see [Enable tool calling on the runtime](#enable-tool-calling-on-the-runtime)) before committing to it. Qwen3-Coder models use `qwen3_xml`; verify Qwen3.6 and Gemma 4 parser support in the vLLM docs for your version.
 - **Budget for context length.** Coding agents send large prompts (system prompt + file and repo context). Pick a model whose context window covers your largest expected prompt, and remember that a longer `--max-model-len` consumes more KV cache per request, reducing concurrency.
 - **Quantization is a force multiplier on-premise.** INT4 (AWQ/GPTQ) or GGUF quantization lets you fit a noticeably more capable model in the same VRAM, which usually matters more for agent quality than raw FP16 precision.
 - **MoE models are especially efficient.** Qwen3.6-35B-A3B and Gemma 4-26B-A4B activate only 3–4B parameters per token while carrying a larger knowledge base, giving near-dense quality at a fraction of the VRAM cost.
@@ -327,7 +398,10 @@ For detailed MLOps workflows — managing InferenceServices, configuring gateway
 - [Speculative Decoding for vLLM Inference Services](../model_inference/inference_service/how_to/vllm_speculative_decoding.mdx)
 - [Extend Inference Runtimes](../model_inference/inference_service/how_to/custom_inference_runtime.mdx)
 - [Tool Calling — vLLM](https://docs.vllm.ai/en/latest/features/tool_calling.html)
+- [Reasoning Outputs — vLLM](https://docs.vllm.ai/en/latest/features/reasoning_outputs/)
 - [Automatic Prefix Caching — vLLM](https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html)
+- [opencode documentation](https://opencode.ai/docs/)
+- [Codex CLI](https://github.com/openai/codex)
 - [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
 - [LiteLLM](https://docs.litellm.ai/)
 - [claude-code-router](https://github.com/musistudio/claude-code-router)

--- a/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
+++ b/docs/en/agentic_mlops/coding-agents-with-inference-service.mdx
@@ -123,14 +123,7 @@ Reasoning effort controls how much the model "thinks" before answering. For codi
 
 #### Server-side defaults
 
-vLLM does not expose a generic `--reasoning-effort` launch flag. For server-wide defaults, configure the model's chat-template thinking knobs instead. For example, Qwen3 enables thinking by default, so you can disable it server-wide:
-
-```bash
---reasoning-parser qwen3 \
---default-chat-template-kwargs '{"enable_thinking": false}'
-```
-
-For models whose templates expose a different thinking switch, use the key documented by the model or vLLM. Request-level `chat_template_kwargs` override the server default.
+vLLM does not expose a generic `--reasoning-effort` launch flag. Server-wide control is achieved through the model's chat template — you can supply a custom Jinja template that disables thinking by default, then pass it with `--chat-template`. Alternatively, some models and vLLM versions expose per-model template kwargs; check the vLLM release notes for the specific key. For a quick start, request-level parameters (see below) are the most portable approach.
 
 #### Request-time override
 

--- a/docs/en/agentic_mlops/mlops-with-coding-agents.mdx
+++ b/docs/en/agentic_mlops/mlops-with-coding-agents.mdx
@@ -77,7 +77,7 @@ For the exact field shape of each CRD, defer to the upstream documentation linke
 
 ## Tune service performance to fit your hardware \{#tune-performance}
 
-The list of vLLM and KServe knobs is unchanged from [Best practices: tune inference service performance](./coding-agents-with-inference-service.mdx#best-practices) — this section focuses on how an agent can *drive* that tuning instead of you doing it by hand.
+This section focuses on how an agent can *drive* tuning instead of you doing it by hand. The server-side knobs differ by runtime — for vLLM, see [Best practices: tune inference service performance](./coding-agents-with-inference-service.mdx#best-practices); for llama.cpp (GGUF), the relevant flags include `--cache-type-k`/`--cache-type-v` (KV cache quantization), `--ctx-size` (context window), `--parallel` (concurrency), and `--reasoning`/`--reasoning-budget` (reasoning control).
 
 A productive loop:
 
@@ -91,32 +91,38 @@ Pin numbers before tuning. Tell the agent what "good enough" looks like:
 - Maximum P95 inter-token latency or total response time for a representative prompt.
 - Minimum sustainable throughput (requests/min or tokens/sec).
 - Maximum context length the agent traffic will send.
+- GPU memory headroom target (leave ≥10% free for KV cache growth).
 
 ### 2. Generate a reproducible benchmark
 
-Ask the agent to write a small benchmark script that mirrors your real traffic — typical prompt size, system prompt, concurrency. Useful starting points include the built-in `vllm bench serve` command, `genai-perf`, or a `k6`/Python script that drives `/v1/chat/completions` directly. Have the agent run it against the current `InferenceService` and record the results in a markdown table.
+Ask the agent to write a benchmark script that mirrors your real traffic — typical prompt size, system prompt, concurrency. Useful starting points include `vllm bench serve`, `genai-perf`, or a `k6`/Python script driving `/v1/chat/completions` directly.
+
+The agent should record **TTFT** (time to first token), **ITL** (inter-token latency in ms/token), and **TPS** (tokens per second) for both streaming and non-streaming requests. If the model serves with reasoning enabled, the agent must also measure the reasoning-overhead ratio: `reasoning_tokens / content_tokens`, because it can inflate total latency and TPS without contributing to the user-visible output.
+
+Ensure the server exposes metrics. For vLLM, scrape the OpenAI-compatible server's built-in `/metrics` endpoint. For llama.cpp, enable the metrics endpoint with `--metrics` before scraping `/metrics`. If the metrics endpoint is unavailable, fall back to per-request latency measurement via the API.
 
 ### 3. Have the agent propose one change at a time
 
-Give the agent the benchmark output and the current YAML. Ask for **one** change with an expected effect, for example:
+Give the agent the benchmark output and current YAML. Ask for **one** change with an expected effect, for example:
 
-- "Add `--enable-prefix-caching` and re-run; expected: lower TTFT on the repeated system-prompt prefix."
-- "Switch the model from FP16 to AWQ INT4 and raise `--gpu-memory-utilization` to 0.92; expected: more KV cache headroom, larger sustainable context length."
-- "Increase `--max-num-seqs`; expected: higher throughput at the cost of higher P95 latency."
+- "Add `--enable-prefix-caching` and re-run; expected: lower TTFT on repeated system-prompt prefixes (vLLM)."
+- "Switch KV cache to `--cache-type-k q8_0 --cache-type-v q8_0` and re-run; expected: fit more context in limited GPU memory (llama.cpp / GGUF)."
+- "Set `--reasoning-budget 2048` instead of `-1`; expected: bounded reasoning overhead, more tokens available for content output (llama.cpp)."
+- "Increase `--max-num-seqs`; expected: higher throughput at the cost of higher P95 latency (vLLM)."
 
 One change per iteration keeps cause and effect attributable.
 
 ### 4. Apply, measure, and record
 
-The agent updates the `InferenceService` YAML, applies it, waits for `READY`, re-runs the benchmark, and appends a new row to the results table with the configuration delta.
+The agent updates the `InferenceService` YAML, applies it, waits for `READY`, and re-runs the benchmark. It should also check GPU-level indicators: utilization (expect 70–90% for sustained inference), memory usage (flag if >95%), and power draw. Each run appends a row to a markdown table with the configuration delta, first-token latency, ITL, TPS, and GPU metrics.
 
 ### 5. Stop on SLO or hardware ceiling
 
-The loop ends when SLOs are met, or when the next sensible knob is "different hardware" or "different model" — at which point the agent should say so explicitly rather than churn. Common ceilings: KV cache saturated at the target context length, tensor-parallel scaling no longer linear, decode-bound at single-request latency.
+The loop ends when SLOs are met, or when the next sensible knob is "different hardware" or "different model" — at which point the agent should say so explicitly rather than churn. Common ceilings: KV cache saturated at the target context length, tensor-parallel scaling no longer linear, decode-bound at single-request latency, or GPU memory headroom below 5%.
 
 </Steps>
 
-For model-size vs. GPU-memory selection, see the table in the prior doc's [Choose a model that fits your hardware](./coding-agents-with-inference-service.mdx#best-practices) section. For autoscaling and cold-start trade-offs, see [Configure Scaling for Inference Services](../model_inference/inference_service/how_to/autoscale_settings.mdx). For interactive-latency wins, see [Speculative Decoding for vLLM Inference Services](../model_inference/inference_service/how_to/vllm_speculative_decoding.mdx).
+For model-size vs. GPU-memory selection, see the prior doc's [Choose a model that fits your hardware](./coding-agents-with-inference-service.mdx#best-practices) section. For autoscaling and cold-start trade-offs, see [Configure Scaling for Inference Services](../model_inference/inference_service/how_to/autoscale_settings.mdx). For interactive-latency wins, see [Speculative Decoding for vLLM Inference Services](../model_inference/inference_service/how_to/vllm_speculative_decoding.mdx).
 
 ## Plan fine-tuning and generate reports \{#fine-tuning-plans-and-reports}
 
@@ -241,6 +247,7 @@ Each step is a separate prompt with its own diff to review. The agent is the typ
 - **Always `--dry-run=server`.** Make it a standing rule in the agent context file; mention it in every prompt that involves `kubectl apply`.
 - **One change per iteration.** Especially for performance tuning, mixing two changes hides which one helped.
 - **Never let the agent fabricate metrics.** Require it to cite the file, log, or run ID it pulled each number from, and to mark `TODO` when data is missing.
+- **Account for reasoning overhead.** When benchmarking reasoning-enabled models, report both total tokens and reasoning-vs-content breakdown. A model emitting 8,000 reasoning tokens before 50 content tokens has 160:1 overhead — that dominates latency and TPS. For llama.cpp, use server-side `--reasoning-budget` to bound it; for other runtimes, use only documented request-time controls that your deployed service accepts.
 - **Keep the loop on-prem.** Confirm that no fallback model in any agent config points at a hosted provider (see [Connect your coding agent](./coding-agents-with-inference-service.mdx) for the per-agent settings to check).
 - **Commit everything.** Plans, reports, generated YAML, and benchmark scripts all go into Git so the next person — or the next agent — can pick up where you left off.
 


### PR DESCRIPTION
## Summary

Extend the coding agents guide to cover reasoning models, Claude Code proxy setup, and model recommendations for on-premise LLMs. Also update the MLOps tuning guide to cover llama.cpp (GGUF) and GPU-level observability.

## Files changed

- `docs/en/agentic_mlops/coding-agents-with-inference-service.mdx`
- `docs/en/agentic_mlops/mlops-with-coding-agents.mdx`

## `coding-agents-with-inference-service.mdx` changes

### Claude Code translation proxy
- Claude Code speaks the Anthropic Messages API and now requires a translation proxy
- Two proxy options documented:
  - **Option 1: LiteLLM proxy** — general-purpose proxy exposing `/v1/messages` endpoint
  - **Option 2: claude-code-router** — Claude Code-specific proxy, config-driven model selection via `~/.claude-code-router/config.json`
- Both options include complete environment variable setup and on-prem guardrail flags

### Step 2b: Configure reasoning models and reasoning effort
- Added server-side flags table mapping model families (DeepSeek R1, QwQ, Qwen3, Hunyuan-A13B, Cohere Command A) to their `--tool-call-parser` + `--reasoning-parser` values
- Documented reasoning effort controls: server-side `--chat-template` defaults, request-time `chat_template_kwargs`, `thinking_token_budget`, and `reasoning_effort` (where supported)
- Removed the incorrect `--default-chat-template-kwargs` flag (non-existent in vLLM)

### Model recommendations
- Added Qwen3.6 and Gemma 4 as recommended model families for coding agents, with vLLM parser guidance
- Added Unsloth quantized models table (8 models: GGUF, QAT, MoE variants)
- Updated hardware fit guide to recommend specific Unsloth models per GPU tier
- Updated "vibe coding" guidance to start with Qwen3.6 or Gemma 4

### Architecture update
- Updated the architecture diagram to show the Claude Code → proxy → InferenceService path separately from opencode/Codex CLI → InferenceService
- Kept opencode and Codex CLI sections — they call the InferenceService directly since they speak OpenAI Chat Completions API natively

## `mlops-with-coding-agents.mdx` changes

### Extended tuning guide for llama.cpp (GGUF)
- Removed vLLM-only framing; added llama.cpp-specific knobs (`--cache-type-k`, `--cache-type-v`, `--ctx-size`, `--parallel`, `--reasoning`/`--reasoning-budget`)
- Added llama.cpp examples in the one-change-per-iteration section

### Reasoning overhead as a benchmarking metric
- Added reasoning-overhead ratio measurement: `reasoning_tokens / content_tokens`
- New best practices guardrail: account for reasoning overhead in benchmark reports

### GPU-level metrics in performance tuning
- Added GPU memory headroom target (≥10% free for KV cache growth)
- Step 4 requires checking GPU utilization, memory usage, and power draw
- Added GPU memory headroom <5% as a hardware ceiling

### Observability guidance
- Added guidance on enabling metrics: vLLM OpenAI-compatible `/metrics` endpoint and llama.cpp `--metrics` flag
- Fallback to per-request latency measurement if metrics endpoint is unavailable

## PR history

This PR builds on the initial coding agents documentation (#245) by extending coverage to reasoning models, Claude Code proxy setup, and model recommendations.