### PR TITLE
docs: add Alauda Build of Spark Operator usage docs

### DIFF
--- a/docs/en/spark_operator/how_to/index.mdx
+++ b/docs/en/spark_operator/how_to/index.mdx
@@ -1,0 +1,11 @@
+---
+weight: 30
+i18n:
+  title:
+    en: How To
+    zh: How To
+---
+
+# How To
+
+<Overview />

--- a/docs/en/spark_operator/how_to/run_spark_application.mdx
+++ b/docs/en/spark_operator/how_to/run_spark_application.mdx
@@ -1,0 +1,230 @@
+---
+weight: 10
+---
+
+# Run a Spark Application
+
+This guide shows how to submit an Apache Spark job with a `SparkApplication` custom resource, monitor it to completion, and inspect the result. It uses the built-in **Spark Pi** example that ships in the Spark image.
+
+## Prerequisites
+
+- Alauda Build of Spark Operator is installed and its CSV reports `Succeeded` — see [Installation](../install.mdx).
+- `kubectl` access to the target cluster.
+
+## 1. Create a namespace and Spark RBAC
+
+In cluster mode the Spark **driver** creates and manages its **executor** pods, so the driver's `ServiceAccount` needs permission to manage pods (and the services / configmaps Spark uses) in its namespace.
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spark-demo
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark
+  namespace: spark-demo
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spark-driver
+  namespace: spark-demo
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps", "persistentvolumeclaims"]
+    verbs: ["create", "get", "list", "watch", "delete", "deletecollection", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spark-driver
+  namespace: spark-demo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spark-driver
+subjects:
+  - kind: ServiceAccount
+    name: spark
+    namespace: spark-demo
+```
+
+Save as `spark-rbac.yaml` and apply:
+
+```bash
+kubectl apply -f spark-rbac.yaml
+```
+
+## 2. Submit a SparkApplication
+
+```yaml
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: SparkApplication
+metadata:
+  name: spark-pi
+  namespace: spark-demo
+spec:
+  type: Scala
+  mode: cluster
+  image: docker.io/library/spark:4.0.1 # [!code callout]
+  imagePullPolicy: IfNotPresent
+  mainClass: org.apache.spark.examples.SparkPi
+  mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples.jar" # [!code callout]
+  arguments: ["100"] # [!code callout]
+  sparkVersion: "4.0.1"
+  restartPolicy:
+    type: Never
+  driver:
+    coreRequest: "500m"
+    coreLimit: "1000m"
+    memory: 512m
+    serviceAccount: spark # [!code callout]
+    securityContext: # [!code callout]
+      runAsUser: 185
+      runAsGroup: 185
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities: { drop: ["ALL"] }
+      seccompProfile: { type: RuntimeDefault }
+  executor:
+    instances: 2 # [!code callout]
+    coreRequest: "500m"
+    coreLimit: "1000m"
+    memory: 512m
+    securityContext:
+      runAsUser: 185
+      runAsGroup: 185
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      capabilities: { drop: ["ALL"] }
+      seccompProfile: { type: RuntimeDefault }
+```
+
+<Callouts>
+
+1. `spec.image` — the Apache Spark runtime image for the driver and executors. On an air-gapped cluster, use the copy relocated into the platform registry (recorded in the CSV `relatedImages`) or your internal mirror, e.g. `build-harbor.alauda.cn/mlops/spark:4.0.1`.
+2. `spec.mainApplicationFile` — path or URL to the application artifact. `local://` refers to a path inside the image; the Spark examples jar ships in the Spark image.
+3. `spec.arguments` — arguments passed to the application; for Spark Pi this is the number of partitions.
+4. `spec.driver.serviceAccount` — must reference the `ServiceAccount` created in step 1.
+5. `spec.driver.securityContext` / `spec.executor.securityContext` — required to satisfy a restricted Pod Security Admission policy. The Spark image runs as UID/GID `185`.
+6. `spec.executor.instances` — number of executor pods to run.
+
+</Callouts>
+
+Save as `spark-pi.yaml` and apply:
+
+```bash
+kubectl apply -f spark-pi.yaml
+```
+
+## 3. Monitor the application
+
+The operator reports progress in `.status.applicationState.state`, which moves through `SUBMITTED` → `RUNNING` → `COMPLETED`.
+
+```bash
+# high-level status
+kubectl get sparkapplication spark-pi -n spark-demo
+
+# just the state field
+kubectl get sparkapplication spark-pi -n spark-demo \
+  -o jsonpath='{.status.applicationState.state}{"\n"}'
+
+# driver and executor pods (driver pod is named <app-name>-driver)
+kubectl get pods -n spark-demo
+```
+
+## 4. Verify the result
+
+When the application reaches `COMPLETED`, check the driver log for the computed value of Pi:
+
+```bash
+kubectl logs spark-pi-driver -n spark-demo | grep "Pi is roughly"
+```
+
+You should see output similar to:
+
+```text
+Pi is roughly 3.1415...
+```
+
+## 5. Clean up
+
+```bash
+kubectl delete sparkapplication spark-pi -n spark-demo
+# optionally remove the demo namespace
+kubectl delete namespace spark-demo
+```
+
+## Schedule a recurring job
+
+To run a Spark application on a schedule, wrap the same application `spec` in a `ScheduledSparkApplication`:
+
+```yaml
+apiVersion: sparkoperator.k8s.io/v1beta2
+kind: ScheduledSparkApplication
+metadata:
+  name: spark-pi-scheduled
+  namespace: spark-demo
+spec:
+  schedule: "@every 5m" # [!code callout]
+  concurrencyPolicy: Forbid # [!code callout]
+  successfulRunHistoryLimit: 3
+  failedRunHistoryLimit: 1
+  template: # [!code callout]
+    type: Scala
+    mode: cluster
+    image: docker.io/library/spark:4.0.1
+    imagePullPolicy: IfNotPresent
+    mainClass: org.apache.spark.examples.SparkPi
+    mainApplicationFile: "local:///opt/spark/examples/jars/spark-examples.jar"
+    arguments: ["100"]
+    sparkVersion: "4.0.1"
+    restartPolicy:
+      type: Never
+    driver:
+      coreRequest: "500m"
+      coreLimit: "1000m"
+      memory: 512m
+      serviceAccount: spark
+    executor:
+      instances: 2
+      coreRequest: "500m"
+      coreLimit: "1000m"
+      memory: 512m
+```
+
+<Callouts>
+
+1. `spec.schedule` — a cron expression (or `@every <duration>`) controlling when runs start.
+2. `spec.concurrencyPolicy` — `Allow`, `Forbid`, or `Replace`; controls overlapping runs.
+3. `spec.template` — the `SparkApplication` spec to run on each tick.
+
+</Callouts>
+
+Inspect the schedule and its generated runs:
+
+```bash
+kubectl get scheduledsparkapplication spark-pi-scheduled -n spark-demo
+kubectl get sparkapplication -n spark-demo
+```
+
+## Common SparkApplication fields
+
+| Field | Description |
+|-------|-------------|
+| `spec.type` | Application language: `Scala`, `Java`, `Python`, or `R`. |
+| `spec.mode` | Submission mode; use `cluster`. |
+| `spec.image` | Spark runtime image for the driver and executors. |
+| `spec.mainClass` | Main class for JVM (`Scala` / `Java`) applications. |
+| `spec.mainApplicationFile` | Path or URL to the application artifact (`local://`, `http(s)://`, `s3a://`, …). |
+| `spec.arguments` | Arguments passed to the application. |
+| `spec.sparkVersion` | Spark version of the image (`4.0.1`). |
+| `spec.sparkConf` | Arbitrary `spark.*` configuration passed to the application. |
+| `spec.deps` | Extra `jars`, `files`, `pyFiles`, and Maven package coordinates to fetch. |
+| `spec.driver` / `spec.executor` | Pod settings: `cores` / `coreRequest` / `coreLimit`, `memory`, `serviceAccount`, `instances` (executor), labels, env, volumes, node selectors, `securityContext`, … |
+| `spec.restartPolicy` | `Never`, `OnFailure`, or `Always`, with retry / backoff settings. |
+
+For the full schema, see the upstream [Spark Operator API reference](https://github.com/kubeflow/spark-operator/blob/master/docs/api-docs.md).

--- a/docs/en/spark_operator/index.mdx
+++ b/docs/en/spark_operator/index.mdx
@@ -1,0 +1,7 @@
+---
+weight: 84
+---
+
+# Alauda Build of Spark Operator
+
+<Overview />

--- a/docs/en/spark_operator/install.mdx
+++ b/docs/en/spark_operator/install.mdx
@@ -1,0 +1,63 @@
+---
+weight: 20
+---
+
+# Installation
+
+Alauda Build of Spark Operator is delivered as an **OLM Operator** and installed from the platform **OperatorHub**.
+
+## Prerequisites
+
+- **ACP version: v4.0 or later** (validated on v4.3 / Kubernetes 1.34).
+- Target cluster architecture `linux/amd64` or `linux/arm64` (the operator ships multi-arch images).
+- Operator Lifecycle Manager (OLM) available on the target cluster (provided by ACP).
+
+## Upload Operator \{#upload-operator}
+
+Download the `Alauda Build of Spark Operator` bundle from the <Term name="company" /> Customer Portal / Marketplace (e.g. `spark-operator.ALL.xxxx.tgz`), then publish it to the platform repository with the `violet` command-line tool:
+
+```bash
+violet push \
+  --platform-address=<platform-access-address> \
+  --platform-username=<platform-admin> \
+  --platform-password=<platform-admin-password> \
+  spark-operator.ALL.xxxx.tgz
+```
+
+:::info
+The operator bundle records its runtime images (the operator image and the Apache Spark runtime image) in the CSV `relatedImages`, so a `violet` release relocates them into the platform registry. This makes the operator installable on **air-gapped** clusters without reaching `docker.io`.
+:::
+
+## Install Operator
+
+In the **Administrator** view:
+
+1. Click **Marketplace** / **OperatorHub**.
+2. At the top of the console, from the **Cluster** dropdown, select the destination cluster.
+3. Search for and select **Alauda Build of Spark Operator**, then click **Install**.
+4. Leave **Channel** unchanged (`stable`).
+5. Check that the **Version** matches the release you want to install (e.g. `v2.5.1`).
+6. Leave **Installation Location** unchanged — it defaults to the `spark-operator` namespace.
+7. Choose an **Upgrade Strategy** (`Manual` is recommended for production).
+8. Click **Install**.
+
+### Verification
+
+Confirm the **Alauda Build of Spark Operator** tile shows `Installed`, then verify on the cluster:
+
+```bash
+# the CSV reports Succeeded
+kubectl get csv -n spark-operator | grep spark-operator
+
+# the operator (controller + webhook) pods are Running
+kubectl get pods -n spark-operator
+
+# the CRDs are registered
+kubectl get crd | grep sparkoperator.k8s.io
+```
+
+The operator watches **all namespaces** by default, so you can create `SparkApplication` resources in any namespace.
+
+:::info
+A `Succeeded` CSV means the operator controller is running. Spark workloads themselves only appear once you create a `SparkApplication` (or `ScheduledSparkApplication`) — see [Run a Spark Application](./how_to/run_spark_application.mdx).
+:::

--- a/docs/en/spark_operator/intro.mdx
+++ b/docs/en/spark_operator/intro.mdx
@@ -1,0 +1,33 @@
+---
+weight: 10
+---
+
+# Introduction
+
+Alauda Build of Spark Operator is a Kubernetes-native operator that runs and manages [Apache Spark](https://spark.apache.org/) applications on Kubernetes. Built on the open-source [Kubeflow Spark Operator](https://github.com/kubeflow/spark-operator), it lets you submit, schedule, monitor, and clean up Spark workloads declaratively through Kubernetes Custom Resource Definitions (CRDs) — without running a `spark-submit` client or a standalone Spark cluster yourself.
+
+## Overview
+
+The operator provides the following CRDs (API group `sparkoperator.k8s.io`):
+
+- **SparkApplication**: Defines a single Spark application (a driver plus its executors). The operator submits it in cluster mode, tracks its lifecycle to completion, and garbage-collects its resources.
+- **ScheduledSparkApplication**: Runs a `SparkApplication` on a cron schedule, with concurrency and run-history controls.
+- **SparkConnect**: Manages a long-running [Spark Connect](https://spark.apache.org/spark-connect/) server for interactive / remote Spark sessions.
+
+## Key Features
+
+- **Declarative submission**: Submit Spark jobs as Kubernetes resources; the operator runs `spark-submit` in cluster mode for you.
+- **Lifecycle management**: Tracks driver/executor state, surfaces `applicationState`, honors the configured restart policy, and cleans up finished applications.
+- **Scheduling**: Cron-style recurring jobs via `ScheduledSparkApplication`.
+- **Admission webhook**: Mutates and validates Spark resources (volumes, affinity, security context, and more).
+- **Batch scheduler integration**: Optional gang scheduling via Volcano or Yunikorn.
+- **Metrics**: Exposes Prometheus metrics for applications, executors, and submission latency.
+
+## Use Cases
+
+- **Batch data processing**: ETL and analytics jobs on Kubernetes.
+- **Scheduled pipelines**: Recurring Spark jobs without an external scheduler.
+- **Distributed data prep / ML**: Large-scale feature engineering and training-data preparation.
+- **Interactive Spark**: Remote Spark sessions through Spark Connect.
+
+This release packages **Apache Spark 4.0.1**. For Spark concepts and Kubernetes specifics, see [Running Spark on Kubernetes](https://spark.apache.org/docs/latest/running-on-kubernetes.html).


### PR DESCRIPTION
Adds a usage section for **Alauda Build of Spark Operator** under `docs/en/spark_operator/`, covering installation and how to create a `SparkApplication`.

### Pages
- **intro** — what the operator is and its CRDs (`SparkApplication`, `ScheduledSparkApplication`, `SparkConnect`); key features; use cases.
- **install** — OLM / OperatorHub install flow (`violet` upload → install from Marketplace → verify CSV/pods/CRDs), with an air-gap note on `relatedImages`. Notes the operator watches all namespaces.
- **how_to/run_spark_application** — submit a `SparkApplication` (the built-in Spark Pi example), the namespace + driver RBAC it needs, monitoring `applicationState` to `COMPLETED`, verifying the result, a `ScheduledSparkApplication` example, and a common-fields reference table.

### Notes
- Mirrors the existing component doc layout (`index` / `intro` / `install` / `how_to`) used by KubeRay, KServe, etc.; integrates into the sidebar via `weight` (84) + `<Overview />`.
- The `SparkApplication` example uses the spec verified end-to-end against the v2.5.1 operator on a dev cluster (Spark Pi → `COMPLETED`), including a PSA-compliant `securityContext`.
- `doom lint` passes with 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)