### PR TITLE
docs(dify): rewrite install guide for the Dify Operator (v1.15.0)

### DIFF
--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -4,43 +4,64 @@ weight: 20
 
 # Install Dify
 
-This document describes how to deploy Dify on **Alauda Container Platform** using the **Dify Operator** (a helm-based OLM operator). The end-to-end flow is:
+This guide installs Dify on **Alauda Container Platform** with the **Dify Operator** (a helm-based OLM operator). Follow the numbered steps in order — every step depends on what was prepared in the previous one.
 
-1. **Publish** the Dify operator package to the platform repository (`violet push`).
-2. **Install the operator** from Marketplace / OperatorHub.
-3. **Prepare external dependencies** — PostgreSQL, Redis, optional pgvector, storage.
-4. **(For Gateway exposure)** install **Envoy Gateway** and create a `Gateway` resource that Dify will attach to.
-5. **(For restricted-network clusters)** deploy in-cluster reverse proxies for the **Dify Marketplace** and **PyPI**.
-6. **Create the Dify resource** and configure it.
+For what Dify is and the components it deploys, see [Introduction](overview/intro).
 
-The operator deploys the Dify workloads only — PostgreSQL, Redis, and the vector store must be provided externally and referenced from the Dify resource.
+## At a Glance
 
-For an overview of Dify and its components, see [Introduction](overview/intro).
+| You need | Why |
+|---|---|
+| The Dify operator package (`.tgz`) | Pushed via `violet` so the operator appears in OperatorHub |
+| External **PostgreSQL 12+** | Dify's main database (only PostgreSQL is supported) |
+| External **Redis 6+** (standalone or Sentinel) | Cache + Celery broker; Cluster mode is **not** supported |
+| External **pgvector** *(optional)* | Vector store for RAG; disable if not using RAG |
+| **RWX PVC** *or* **S3-compatible storage** | Shared, writable storage for the API + Plugin Daemon |
+| **Two browser-facing hostnames** with TLS certs | One for the **Console** (builder UI), one for **App** (published apps). See [Why Dify needs two URLs](#why-two-urls) |
+| **Envoy Gateway** + a `Gateway` resource | Production exposure via Gateway API HTTPRoute |
+| **In-cluster proxies** (Marketplace + PyPI) *(restricted-network only)* | Lets plugins install without public internet |
 
-## Components
+:::info
+For dev / internal use you can skip Envoy Gateway and reach Dify via NodePort. See [Step 7 — Create the Dify resource](#create-the-dify-resource).
+:::
 
-The operator runs the following Dify components as separate workloads:
+## Why Dify Needs Two URLs \{#why-two-urls}
 
-- **API** – Backend API and business logic
-- **Worker** / **Worker Beat** – Celery workers and scheduler for async/scheduled tasks
-- **Web** – Frontend UI
-- **Plugin Daemon** – Plugin runtime
-- **Sandbox** – Isolated code execution
-- **SSRF Proxy** – Squid-based proxy for outbound requests
+Dify exposes **two browser-facing surfaces**, so the operator's CR has two URL fields:
 
-## Prerequisites
+| Field | Audience | Serves |
+|---|---|---|
+| `consoleUrl` | Admins / app builders | The builder UI: create apps, configure models, manage knowledge bases |
+| `appUrl` | End users of published apps | Published chat / agent apps (e.g. `/chat/<code>`) |
 
-- **Alauda Container Platform** with a target cluster (Kubernetes 1.21+) and cluster-admin access.
-- External **PostgreSQL 12+** (only PostgreSQL is supported for the main database).
-- External **Redis 6.0+** — **standalone or Sentinel (HA)**; Redis Cluster is not supported.
-- For RAG: **PostgreSQL with the pgvector extension** (optional — can be disabled if you don't use RAG).
-- Storage for the API and Plugin Daemon: a **RWX** PersistentVolume StorageClass **or** an S3-compatible object store.
-- **For Gateway API exposure (recommended):** the **Gateway API CRDs** and a Gateway implementation (this guide uses **Envoy Gateway**).
-- **For restricted-network clusters:** in-cluster reverse proxies to the Dify Marketplace and to PyPI (see [Restricted network](#restricted-network)).
+The split exists so you can separate **admin access** from **end-user access** — different DNS, different certs, different network exposure (e.g. console internal only, app reachable from the internet).
 
-## Publish the Operator Package
+**You may reuse one hostname for both** (set `consoleUrl` and `appUrl` to the same host) — fine for dev/internal. For production we recommend two separate hostnames.
 
-The Dify operator is delivered as an installation package (e.g. `dify-operator.alpha.ALL.v<version>.tgz`). Publish it to the platform's local repository so it appears in **Marketplace / OperatorHub**:
+:::warning
+The host part of `consoleUrl` / `appUrl` **must match** the hostname users actually reach Dify on (Gateway hostname or NodePort address). If it doesn't, the frontend cannot load — Dify uses these URLs to build its own asset and API links.
+:::
+
+## Step 1 — Prepare Hostnames and TLS
+
+Decide your hostnames now; they are referenced from Step 5 (Gateway), Step 6 (in-cluster proxies), and Step 7 (Dify resource).
+
+1. **Choose hostnames** — two separate hosts (recommended) or a single shared host:
+   - Two: e.g. `dify-console.example.com` and `dify-app.example.com`
+   - One: e.g. `dify.example.com` used for both
+2. **Point DNS** for each hostname to the cluster's Gateway external IP / LoadBalancer.
+3. **Obtain a TLS certificate** covering all chosen hostnames (cert-manager, an internal CA, or a precreated PEM).
+4. **Create a TLS Secret** in the namespace where you will create the `Gateway`:
+
+   ```bash
+   kubectl create secret tls dify-tls \
+     --cert=tls.crt --key=tls.key \
+     -n <gateway-namespace>
+   ```
+
+## Step 2 — Publish the Operator Package
+
+Download the Dify operator package (for example `dify-operator.alpha.ALL.v<version>.tgz`) from Customer Support / Portal, then push it to the platform repository so it appears in Marketplace / OperatorHub:
 
 ```bash
 violet push \
@@ -50,45 +71,45 @@ violet push \
   dify-operator.alpha.ALL.v<version>.tgz
 ```
 
-After `violet push` succeeds, the operator becomes installable from the cluster's **Marketplace / OperatorHub** view.
+## Step 3 — Install the Operator
 
-## Install the Operator
+In **Administrator** view of Alauda Container Platform:
 
-1. Sign in to **Alauda Container Platform** as a cluster administrator.
-2. Open the target cluster's **Marketplace / OperatorHub**, find **Dify**, and **Install** it.
-3. After the operator is running you can create one or more **Dify** instances — see [Required Configuration](#required-configuration) and the optional sections.
+1. Open **Marketplace** / **OperatorHub** and select the target cluster.
+2. Search for **Dify**, click **Install**, and keep defaults unless you need a non-default namespace.
+3. Wait for the tile to show **Installed**.
 
-## Prepare Dependencies
+## Step 4 — Prepare External Dependencies
 
 ### PostgreSQL (required)
 
-Use **PostgreSQL 12+**. You can create a PostgreSQL cluster via the **PostgreSQL operator in Data Services**, then read the host and credentials from the instance details. Create an empty database for Dify (e.g. `dify`).
+Use **PostgreSQL 12+**. The simplest path is the PostgreSQL operator in **Data Services**: create a cluster, then create an empty database for Dify (e.g. `dify`). Record the host, port, username, and password.
 
 ### Redis (required — standalone or Sentinel)
 
-Use **Redis 6.0+**. You can create a Redis instance via **Data Services**.
+Use **Redis 6.0+**. Create via **Data Services**.
 
-- **Standalone:** when creating the instance, select **Redis Sentinel** for Architecture, switch to **YAML**, set `spec.arch` to `standalone`, then create. The read-write Service is `rfr-<instance>-read-write`.
-- **Sentinel (HA):** keep the Sentinel architecture; use the Sentinel Service endpoints and master name (see [Redis Sentinel (HA)](#redis-sentinel-ha)).
+- **Standalone:** create with **Redis Sentinel** architecture, switch to **YAML**, set `spec.arch: standalone`, and create. Use the `rfr-<instance>-read-write` Service as the Redis host.
+- **Sentinel (HA):** keep the Sentinel architecture; use the Sentinel Service endpoints + master name in Step 7 ([Redis Sentinel](#redis-sentinel)).
 
-### Vector store / pgvector (optional, for RAG)
+### pgvector — vector store *(optional, for RAG)*
 
-Only **pgvector** is supported. Use a PostgreSQL instance with the pgvector extension (the same host as the main database with a different database name, or a dedicated host). If you do not use RAG, set `vectorStore.enabled: false`.
+Only **pgvector** is supported. Use a PostgreSQL instance with the `pgvector` extension installed. It can share the main DB host (different database name) or be a dedicated host. Skip if you don't use RAG.
 
-### Storage (RWX PVC or S3)
+### Storage — RWX PVC or S3
 
-The API and Plugin Daemon need shared, writable storage. Use either:
+The API, Worker, Worker-Beat and Plugin Daemon need shared writable storage:
 
-- a **PVC** backed by a **ReadWriteMany (RWX)** StorageClass (the API, worker and worker-beat share it), or
-- an **S3-compatible** object store (recommended when no RWX class is available; see [Storage — PVC (RWX) or S3](#storage)).
+- **RWX PVC** — a `ReadWriteMany` StorageClass shared across the workloads, **or**
+- **S3-compatible** object storage (MinIO, AWS S3, OBS, etc.) — recommended when no RWX class is available.
 
-## Set up the Gateway (for Gateway API exposure)
+Record either the StorageClass name, or the S3 endpoint + region + bucket + access keys.
 
-If you want to expose Dify via Gateway API (recommended for production), install **Envoy Gateway** into the cluster **before** creating the Dify resource.
+## Step 5 — Install Envoy Gateway and Create the Gateway
 
-### Install Envoy Gateway
+If you will reach Dify via Gateway API, set up the Gateway **before** creating the Dify resource. (Skip this step if you will use NodePort only.)
 
-Install Envoy Gateway via its Helm chart (or via the Envoy Gateway operator if available in your Marketplace):
+### 5.1 Install Envoy Gateway
 
 ```bash
 helm install eg oci://docker.io/envoyproxy/gateway-helm \
@@ -96,169 +117,55 @@ helm install eg oci://docker.io/envoyproxy/gateway-helm \
   --namespace envoy-gateway-system --create-namespace
 ```
 
-Verify the controller is running:
+Verify:
 
 ```bash
 kubectl -n envoy-gateway-system get pods
-kubectl get gatewayclass
+kubectl get gatewayclass               # expect a GatewayClass named `eg`
 ```
 
-You should see at least one `GatewayClass` named `eg` (or similar).
+### 5.2 Create the `Gateway`
 
-### Create a Gateway resource
-
-Create a `Gateway` with the listeners Dify needs (one or two HTTPS listeners — for `consoleUrl` and `appUrl`, which can share a host or use separate hosts). The Dify resource's `httpRoute` will reference this Gateway by name.
+The Dify resource's `httpRoute` will reference this Gateway by name. The TLS Secret comes from [Step 1](#step-1--prepare-hostnames-and-tls).
 
 ```yaml
-# TLS certificate for the listener
-apiVersion: v1
-kind: Secret
-metadata:
-  name: dify-tls
-  namespace: <gateway-namespace>
-type: kubernetes.io/tls
-data:
-  tls.crt: <base64-cert>
-  tls.key: <base64-key>
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: dify
   namespace: <gateway-namespace>
 spec:
-  gatewayClassName: eg                     # match the installed GatewayClass
+  gatewayClassName: eg
   listeners:
     - name: https
       protocol: HTTPS
       port: 443
-      hostname: "*.example.com"            # or specific hosts
+      hostname: "*.example.com"          # covers console + app hosts; can use specific hostnames instead
       tls:
         mode: Terminate
         certificateRefs:
-          - {name: dify-tls}
+          - {name: dify-tls}              # from Step 1
       allowedRoutes:
         namespaces:
-          from: All                        # allow HTTPRoutes from the Dify namespace
+          from: All                       # allow HTTPRoute from the Dify namespace
 ```
 
-The Dify resource's `httpRoute.gatewayName` / `httpRoute.gatewayNamespace` / `httpRoute.hostnames` will reference this Gateway. Make sure `consoleUrl` / `appUrl` use the same hostnames so the browser reaches the right host.
-
-## Required Configuration
-
-Create the connection secrets (the **key names must match** what the operator reads):
+After applying, confirm the Gateway is `Accepted` and has an assigned address:
 
 ```bash
-# DB / Redis / pgvector passwords are read from key `password`
-kubectl create secret generic dify-db       --from-literal=password='<db-password>'
-kubectl create secret generic dify-redis    --from-literal=password='<redis-password>'    # omit if Redis has no auth
-kubectl create secret generic dify-pgvector --from-literal=password='<pgvector-password>'
+kubectl get gateway dify -n <gateway-namespace> -o wide
 ```
 
-Minimal Dify resource fields (form or YAML):
+## Step 6 — Deploy In-Cluster Proxies *(restricted-network only)* \{#proxies}
 
-```yaml
-# Browser-facing base URLs (no path suffix) — required so the frontend loads correctly
-consoleUrl: https://<console-host>
-appUrl: https://<app-host>
+Skip this step on clusters with public internet. On restricted-network clusters Dify needs in-cluster reverse proxies for:
 
-database:
-  host: <postgres-host>      # host only, no port
-  port: 5432
-  username: postgres
-  name: dify
-  secret: dify-db            # Secret holding key `password`
-  sslEnabled: false
+- **Dify Marketplace** — for plugin install. Upstream is `https://marketplace.dify.ai` and requires `Host: marketplace.dify.ai`.
+- **PyPI** — for plugin Python dependencies (the Plugin Daemon's `uv sync`).
 
-redis:
-  mode: standalone           # standalone | sentinel
-  host: <redis-host>
-  port: 6379
-  secret: dify-redis         # optional; omit if Redis has no auth
-  cacheDB: 0
-  brokerDB: 1
+The example below uses Nginx. Adjust namespace and upstreams for your environment.
 
-vectorStore:
-  enabled: true              # set false to disable RAG / pgvector
-  host: <pgvector-host>
-  port: 5432
-  username: postgres
-  name: dify_vector
-  secret: dify-pgvector
-```
-
-## Optional Configuration
-
-### Redis Sentinel (HA) \{#redis-sentinel-ha}
-
-Both the cache and the Celery broker run over Sentinel:
-
-```yaml
-redis:
-  mode: sentinel
-  sentinels: "<host1>:26379,<host2>:26379,<host3>:26379"
-  masterName: mymaster
-  secret: dify-redis            # Redis AUTH password (key `password`), if any
-  sentinelSecret: dify-sentinel # Sentinel AUTH password (key `password`), if any
-```
-
-### Database SSL
-
-```yaml
-database:
-  sslEnabled: true
-```
-
-### Storage — PVC (RWX) or S3 \{#storage}
-
-**PVC (RWX):**
-
-```yaml
-storage:
-  type: PVC
-  storageClass: <rwx-storage-class>
-  size: 20Gi
-```
-
-**S3 / S3-compatible:** create a Secret with keys `accessKey` and `secretKey`:
-
-```bash
-kubectl create secret generic dify-s3 --from-literal=accessKey='<ak>' --from-literal=secretKey='<sk>'
-```
-
-```yaml
-storage:
-  type: S3
-  endpoint: https://<s3-endpoint>   # e.g. http://minio.minio-system:9000 for MinIO
-  region: us-east-1
-  apiBucket: dify
-  pluginBucket: dify-plugin
-  s3Secret: dify-s3                 # keys: accessKey / secretKey
-  s3PathStyle: true                 # true for MinIO / most S3-compatible endpoints; false for AWS
-```
-
-### Expose via Gateway API (HTTPRoute) \{#httproute}
-
-Attach Dify to the Gateway you set up in [Set up the Gateway](#set-up-the-gateway-for-gateway-api-exposure):
-
-```yaml
-httpRoute:
-  gatewayName: dify
-  gatewayNamespace: <gateway-namespace>
-  sectionName: https                 # optional; the Gateway listener to bind
-  hostnames:
-    - <dify.example.com>
-```
-
-Make sure `consoleUrl` / `appUrl` match the hostnames.
-
-### Restricted network \{#restricted-network}
-
-When the cluster cannot reach the public Dify Marketplace (`https://marketplace.dify.ai`) or PyPI, install plugins through **in-cluster reverse proxies**.
-
-#### Deploy a Marketplace reverse proxy
-
-The upstream requires `Host: marketplace.dify.ai`. A minimal Nginx proxy:
+### 6.1 Marketplace reverse proxy
 
 ```yaml
 apiVersion: v1
@@ -304,34 +211,147 @@ spec:
   ports: [{port: 80, targetPort: 80}]
 ```
 
-#### Deploy a PIP mirror proxy (optional)
+### 6.2 PyPI reverse proxy
 
-Either point at a public mirror reachable from the cluster (e.g. `https://mirrors.aliyun.com/pypi/simple/`) or stand up a similar Nginx reverse proxy to it. For a self-hosted PyPI cache, [devpi](https://www.devpi.net/) is also an option.
+Point at any PyPI mirror your cluster can reach (e.g. `https://mirrors.aliyun.com/pypi/simple/`). Use the same Nginx pattern as 6.1, or any PyPI cache such as [devpi](https://www.devpi.net/). Expose it as Service `dify-pip-proxy`.
 
-#### Configure Dify to use the proxies
+## Step 7 — Create the Dify Resource \{#create-the-dify-resource}
+
+### 7.1 Connection secrets
+
+```bash
+# DB / Redis / pgvector passwords are read from key `password`
+kubectl create secret generic dify-db       --from-literal=password='<db-password>'
+kubectl create secret generic dify-redis    --from-literal=password='<redis-password>'    # omit if Redis has no auth
+kubectl create secret generic dify-pgvector --from-literal=password='<pgvector-password>'
+
+# S3 only — keys must be `accessKey` and `secretKey`
+kubectl create secret generic dify-s3 --from-literal=accessKey='<ak>' --from-literal=secretKey='<sk>'
+```
+
+### 7.2 Minimal Dify resource
+
+```yaml
+# Browser-facing base URLs (no path suffix). Hostnames from Step 1.
+consoleUrl: https://dify-console.example.com
+appUrl:     https://dify-app.example.com
+
+database:
+  host: <postgres-host>
+  port: 5432
+  username: postgres
+  name: dify
+  secret: dify-db
+  sslEnabled: false
+
+redis:
+  mode: standalone           # standalone | sentinel
+  host: <redis-host>
+  port: 6379
+  secret: dify-redis         # omit if no auth
+  cacheDB: 0
+  brokerDB: 1
+
+vectorStore:
+  enabled: true              # set false to disable RAG
+  host: <pgvector-host>
+  port: 5432
+  username: postgres
+  name: dify_vector
+  secret: dify-pgvector
+
+# Choose ONE of the storage blocks — RWX PVC or S3
+storage:
+  type: PVC                  # PVC | S3
+  storageClass: <rwx-storage-class>
+  size: 20Gi
+
+# Production exposure via Gateway API — refers to the Gateway created in Step 5
+httpRoute:
+  gatewayName: dify
+  gatewayNamespace: <gateway-namespace>
+  hostnames:
+    - dify-console.example.com
+    - dify-app.example.com
+```
+
+### 7.3 Add-ons
+
+#### Redis Sentinel (HA) \{#redis-sentinel}
+
+```yaml
+redis:
+  mode: sentinel
+  sentinels: "<host1>:26379,<host2>:26379,<host3>:26379"
+  masterName: mymaster
+  secret: dify-redis             # Redis AUTH password, if any
+  sentinelSecret: dify-sentinel  # Sentinel AUTH password, if any
+```
+
+#### Storage on S3
+
+```yaml
+storage:
+  type: S3
+  endpoint: https://<s3-endpoint>   # e.g. http://minio.minio-system:9000 for MinIO
+  region: us-east-1
+  apiBucket: dify
+  pluginBucket: dify-plugin
+  s3Secret: dify-s3                 # keys: accessKey / secretKey
+  s3PathStyle: true                 # true for MinIO / most S3-compatible; false for AWS
+```
+
+#### Database SSL
+
+```yaml
+database:
+  sslEnabled: true
+```
+
+#### Restricted network — use the proxies from [Step 6](#proxies)
 
 ```yaml
 proxy:
   marketplace: true
   # FQDN required — the API's SSRF proxy (squid) cannot resolve short in-cluster names
   marketplaceURL: http://dify-marketplace-proxy.<ns>.svc.cluster.local
-  pipMirrorUrl: http://dify-pip-proxy.<ns>.svc.cluster.local/pypi/simple/
-  ignoreUvLock: true            # drop `uv sync --frozen` so plugin deps resolve via the PIP mirror
-  pluginInitTimeout: 1200       # raise from the 120s default for slow mirrors
+  pipMirrorUrl:   http://dify-pip-proxy.<ns>.svc.cluster.local/pypi/simple/
+  ignoreUvLock: true            # drop `uv sync --frozen` so plugin deps come from the PIP mirror
+  pluginInitTimeout: 1200       # raise from 120s default for slow mirrors
   verifyPluginSignature: false  # allow repackaged / offline plugin packages
 ```
 
-Important notes:
+To disable the Marketplace entirely instead, set `proxy.marketplace: false` and install plugins via **Install via Local Package File** in the console. See [Dify: Installing the Plugin](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/release-by-file#installing-the-plugin).
 
-- `marketplaceURL` must be an **FQDN** — the SSRF proxy cannot resolve short in-cluster names.
-- By default plugin installs run `uv sync --frozen`, which pins PyPI and **bypasses** `pipMirrorUrl`. Set `ignoreUvLock: true` so plugin Python dependencies are fetched from the mirror.
-- To disable the marketplace entirely instead, set `proxy.marketplace: false` and install plugins via **Install via Local Package File** in the console. See [Dify: Installing the Plugin](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/release-by-file#installing-the-plugin).
+#### NodePort exposure (no domain prep) \{#nodeport}
 
-## Access
+Skip Steps 1 and 5. Expose the API and Web Services as NodePort (or use the platform's Service exposure UI), then set `consoleUrl` / `appUrl` to the reachable node address — for example `http://<node-ip>:<nodeport>`. Do not set `httpRoute`.
 
-- **Via Gateway:** open `consoleUrl` (builder UI) and `appUrl` (published apps) once the HTTPRoute is Accepted.
-- **Via Service / NodePort:** expose the API and Web Services and set `consoleUrl` / `appUrl` to the reachable address (for example `http://<node-ip>:<nodeport>`); the host in these URLs must match how users actually reach Dify, otherwise the frontend will not load.
+## Step 8 — Access and Initial Setup
 
-## User Management
+1. Wait until the Dify resource reports its workloads `Ready`.
+2. Open `consoleUrl` in a browser; Dify will prompt for **initial admin setup** (email + password) on first sign-in.
+3. After signing in, create additional users from the console.
+4. Visit `appUrl` to confirm published-app access (you can publish a quick test app from the console to verify).
 
-Dify has no default admin. After the instance is running, open `consoleUrl` and complete the initial admin setup (email + password) on the first sign-in, then create additional users from the console.
+## Reference: Dify Resource Fields
+
+Top-level fields exposed by the Dify resource:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `consoleUrl` | string | Browser URL for the Console (builder UI). See [Why two URLs](#why-two-urls). |
+| `appUrl` | string | Browser URL for published apps. |
+| `database.{host, port, username, name, secret, sslEnabled}` | object | External PostgreSQL connection. `secret` holds key `password`. |
+| `redis.{mode, host, port, sentinels, masterName, secret, sentinelSecret, cacheDB, brokerDB, sslEnabled}` | object | External Redis. `mode = standalone | sentinel`. |
+| `vectorStore.{enabled, host, port, username, name, secret}` | object | pgvector. `enabled: false` disables RAG. |
+| `storage.{type, storageClass, size, endpoint, apiBucket, pluginBucket, s3Secret, region, s3PathStyle}` | object | `type = PVC | S3`. |
+| `httpRoute.{gatewayName, gatewayNamespace, sectionName, hostnames}` | object | Gateway API exposure. Omit for NodePort. |
+| `proxy.{marketplace, marketplaceURL, pipMirrorUrl, ignoreUvLock, pluginInitTimeout, verifyPluginSignature}` | object | Plugin install behavior for restricted networks. |
+
+Secret-key conventions:
+
+| Secret | Key(s) |
+|---|---|
+| `database.secret` / `redis.secret` / `redis.sentinelSecret` / `vectorStore.secret` | `password` |
+| `storage.s3Secret` | `accessKey`, `secretKey` |

--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -4,7 +4,7 @@ weight: 20
 
 # Install Dify
 
-This guide installs Dify on **Alauda Container Platform** with the **Dify Operator** (a helm-based OLM operator). Follow the numbered steps in order — every step depends on what was prepared in the previous one.
+This guide installs Dify on **Alauda Container Platform** using the **Dify Operator** (a helm-based OLM operator). Follow the steps in order — each one depends on the previous.
 
 For what Dify is and the components it deploys, see [Introduction](overview/intro).
 
@@ -16,52 +16,13 @@ For what Dify is and the components it deploys, see [Introduction](overview/intr
 | External **PostgreSQL 12+** | Dify's main database (only PostgreSQL is supported) |
 | External **Redis 6+** (standalone or Sentinel) | Cache + Celery broker; Cluster mode is **not** supported |
 | External **pgvector** *(optional)* | Vector store for RAG; disable if not using RAG |
-| **RWX PVC** *or* **S3-compatible storage** | Shared, writable storage for the API + Plugin Daemon |
-| **Two browser-facing hostnames** with TLS certs | One for the **Console** (builder UI), one for **App** (published apps). See [Why Dify needs two URLs](#why-two-urls) |
-| **Envoy Gateway** + a `Gateway` resource | Production exposure via Gateway API HTTPRoute |
-| **In-cluster proxies** (Marketplace + PyPI) *(restricted-network only)* | Lets plugins install without public internet |
+| **RWX PVC** *or* **S3-compatible storage** | Shared, writable storage for API + Plugin Daemon |
+| An **access method** for browsers | One of: NodePort/Service, single domain, or two domains. See [Step 4](#access-method) |
+| **In-cluster proxies** *(restricted-network only)* | A Marketplace reverse proxy + a PyPI mirror so plugins install offline |
 
-:::info
-For dev / internal use you can skip Envoy Gateway and reach Dify via NodePort. See [Step 7 — Create the Dify resource](#create-the-dify-resource).
-:::
+## Step 1 — Publish the Operator Package
 
-## Why Dify Needs Two URLs \{#why-two-urls}
-
-Dify exposes **two browser-facing surfaces**, so the operator's CR has two URL fields:
-
-| Field | Audience | Serves |
-|---|---|---|
-| `consoleUrl` | Admins / app builders | The builder UI: create apps, configure models, manage knowledge bases |
-| `appUrl` | End users of published apps | Published chat / agent apps (e.g. `/chat/<code>`) |
-
-The split exists so you can separate **admin access** from **end-user access** — different DNS, different certs, different network exposure (e.g. console internal only, app reachable from the internet).
-
-**You may reuse one hostname for both** (set `consoleUrl` and `appUrl` to the same host) — fine for dev/internal. For production we recommend two separate hostnames.
-
-:::warning
-The host part of `consoleUrl` / `appUrl` **must match** the hostname users actually reach Dify on (Gateway hostname or NodePort address). If it doesn't, the frontend cannot load — Dify uses these URLs to build its own asset and API links.
-:::
-
-## Step 1 — Prepare Hostnames and TLS
-
-Decide your hostnames now; they are referenced from Step 5 (Gateway), Step 6 (in-cluster proxies), and Step 7 (Dify resource).
-
-1. **Choose hostnames** — two separate hosts (recommended) or a single shared host:
-   - Two: e.g. `dify-console.example.com` and `dify-app.example.com`
-   - One: e.g. `dify.example.com` used for both
-2. **Point DNS** for each hostname to the cluster's Gateway external IP / LoadBalancer.
-3. **Obtain a TLS certificate** covering all chosen hostnames (cert-manager, an internal CA, or a precreated PEM).
-4. **Create a TLS Secret** in the namespace where you will create the `Gateway`:
-
-   ```bash
-   kubectl create secret tls dify-tls \
-     --cert=tls.crt --key=tls.key \
-     -n <gateway-namespace>
-   ```
-
-## Step 2 — Publish the Operator Package
-
-Download the Dify operator package (for example `dify-operator.alpha.ALL.v<version>.tgz`) from Customer Support / Portal, then push it to the platform repository so it appears in Marketplace / OperatorHub:
+Download the Dify operator package (e.g. `dify-operator.alpha.ALL.v<version>.tgz`) from Customer Support / Portal, then push it to the platform repository so it appears in **Marketplace / OperatorHub**:
 
 ```bash
 violet push \
@@ -71,7 +32,7 @@ violet push \
   dify-operator.alpha.ALL.v<version>.tgz
 ```
 
-## Step 3 — Install the Operator
+## Step 2 — Install the Dify Operator
 
 In **Administrator** view of Alauda Container Platform:
 
@@ -79,18 +40,18 @@ In **Administrator** view of Alauda Container Platform:
 2. Search for **Dify**, click **Install**, and keep defaults unless you need a non-default namespace.
 3. Wait for the tile to show **Installed**.
 
-## Step 4 — Prepare External Dependencies
+## Step 3 — Prepare External Dependencies
 
 ### PostgreSQL (required)
 
-Use **PostgreSQL 12+**. The simplest path is the PostgreSQL operator in **Data Services**: create a cluster, then create an empty database for Dify (e.g. `dify`). Record the host, port, username, and password.
+Use **PostgreSQL 12+**. The simplest path is the PostgreSQL operator in **Data Services**: create a cluster, then create an empty database for Dify (e.g. `dify`). Record the host, port, username and password.
 
 ### Redis (required — standalone or Sentinel)
 
 Use **Redis 6.0+**. Create via **Data Services**.
 
 - **Standalone:** create with **Redis Sentinel** architecture, switch to **YAML**, set `spec.arch: standalone`, and create. Use the `rfr-<instance>-read-write` Service as the Redis host.
-- **Sentinel (HA):** keep the Sentinel architecture; use the Sentinel Service endpoints + master name in Step 7 ([Redis Sentinel](#redis-sentinel)).
+- **Sentinel (HA):** keep the Sentinel architecture; use the Sentinel Service endpoints + master name in [Step 6](#create-the-instance).
 
 ### pgvector — vector store *(optional, for RAG)*
 
@@ -100,33 +61,39 @@ Only **pgvector** is supported. Use a PostgreSQL instance with the `pgvector` ex
 
 The API, Worker, Worker-Beat and Plugin Daemon need shared writable storage:
 
-- **RWX PVC** — a `ReadWriteMany` StorageClass shared across the workloads, **or**
-- **S3-compatible** object storage (MinIO, AWS S3, OBS, etc.) — recommended when no RWX class is available.
+- a **ReadWriteMany (RWX)** StorageClass shared across the workloads, **or**
+- an **S3-compatible** object store (MinIO, AWS S3, OBS, etc.) — recommended when no RWX class is available.
 
-Record either the StorageClass name, or the S3 endpoint + region + bucket + access keys.
+Record the StorageClass name, or the S3 endpoint + region + bucket + access keys.
 
-## Step 5 — Install Envoy Gateway and Create the Gateway
+## Step 4 — Decide and Set Up the Access Method \{#access-method}
 
-If you will reach Dify via Gateway API, set up the Gateway **before** creating the Dify resource. (Skip this step if you will use NodePort only.)
+Dify is browser-facing and has **two surfaces**, so the Dify instance has two URL fields:
 
-### 5.1 Install Envoy Gateway
+- **Console URL** — the builder UI used by admins / app creators (build apps, configure models, manage knowledge bases).
+- **App URL** — the published apps that end users open (chat / agent pages like `/chat/<code>`).
+
+Both URLs must match how users actually reach Dify, otherwise the frontend cannot load. Pick one of the three options below — each says what you need to prepare and how the two URLs are filled.
+
+| Option | When to use | What to prepare | Console URL / App URL |
+|---|---|---|---|
+| **A. NodePort / Service IP** | Dev / internal; no domain | Nothing | Both set to `http://<node-ip>:<nodeport>` (one address used for both) |
+| **B. Single domain** | One hostname for both surfaces | 1 DNS record + 1 TLS cert; an Envoy Gateway instance + Gateway resource | Both set to `https://<host>` |
+| **C. Two domains** | Production — separate admin vs end-user access (different DNS / cert / network exposure) | 2 DNS records + TLS cert(s); an Envoy Gateway instance + Gateway resource | Console URL = `https://<console-host>`, App URL = `https://<app-host>` |
+
+For **Option A** there is nothing to set up here — go to Step 5. For **Options B and C**, set up the Gateway as follows.
+
+### Set Up the Gateway (Option B or C only)
+
+ACP includes the **Alauda Build of Envoy Gateway** operator. If it isn't installed yet, install it from **Marketplace / OperatorHub** — see <ExternalSiteLink name="acp" href="/networking/operators/envoy_gateway_operator.mdx" children="install_envoy_gateway_operator" />.
+
+Then prepare a TLS Secret and create a `Gateway` resource. The Dify instance's HTTP Route will reference this Gateway in Step 6.
 
 ```bash
-helm install eg oci://docker.io/envoyproxy/gateway-helm \
-  --version v1.2.4 \
-  --namespace envoy-gateway-system --create-namespace
+kubectl create secret tls dify-tls \
+  --cert=tls.crt --key=tls.key \
+  -n <gateway-namespace>
 ```
-
-Verify:
-
-```bash
-kubectl -n envoy-gateway-system get pods
-kubectl get gatewayclass               # expect a GatewayClass named `eg`
-```
-
-### 5.2 Create the `Gateway`
-
-The Dify resource's `httpRoute` will reference this Gateway by name. The TLS Secret comes from [Step 1](#step-1--prepare-hostnames-and-tls).
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
@@ -135,104 +102,66 @@ metadata:
   name: dify
   namespace: <gateway-namespace>
 spec:
-  gatewayClassName: eg
+  gatewayClassName: <envoy-gateway-class>    # the GatewayClass exposed by Envoy Gateway
   listeners:
     - name: https
       protocol: HTTPS
       port: 443
-      hostname: "*.example.com"          # covers console + app hosts; can use specific hostnames instead
+      hostname: "*.example.com"               # cover both console + app hostnames
       tls:
         mode: Terminate
         certificateRefs:
-          - {name: dify-tls}              # from Step 1
+          - {name: dify-tls}
       allowedRoutes:
         namespaces:
-          from: All                       # allow HTTPRoute from the Dify namespace
+          from: All
 ```
 
-After applying, confirm the Gateway is `Accepted` and has an assigned address:
+Point DNS for each hostname at the Gateway's external address (`kubectl get gateway dify -n <gateway-namespace> -o wide`).
 
-```bash
-kubectl get gateway dify -n <gateway-namespace> -o wide
-```
+## Step 5 — Provide Plugin-Install Proxies *(restricted network only)*
 
-## Step 6 — Deploy In-Cluster Proxies *(restricted-network only)* \{#proxies}
+Skip this step on clusters with public internet. Otherwise prepare two HTTP-reachable proxies (deploy them however you like — Nginx, an existing API gateway, devpi, etc.):
 
-Skip this step on clusters with public internet. On restricted-network clusters Dify needs in-cluster reverse proxies for:
+- **Marketplace reverse proxy** — proxies to `https://marketplace.dify.ai`, **preserving the `Host: marketplace.dify.ai` header**. Note its Service URL.
+- **PyPI mirror** — serves a PyPI simple index (e.g. proxies `https://mirrors.aliyun.com/pypi/simple/`, or any PyPI cache). Note its Service URL.
 
-- **Dify Marketplace** — for plugin install. Upstream is `https://marketplace.dify.ai` and requires `Host: marketplace.dify.ai`.
-- **PyPI** — for plugin Python dependencies (the Plugin Daemon's `uv sync`).
+:::warning
+The Marketplace proxy URL **must be an FQDN** (e.g. `http://dify-marketplace-proxy.<ns>.svc.cluster.local`) — Dify's internal SSRF proxy (squid) cannot resolve short in-cluster names.
+:::
 
-The example below uses Nginx. Adjust namespace and upstreams for your environment.
+## Step 6 — Create the Dify Instance \{#create-the-instance}
 
-### 6.1 Marketplace reverse proxy
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata: {name: dify-marketplace-proxy, namespace: <ns>}
-data:
-  nginx.conf: |
-    events {}
-    http {
-      resolver kube-dns.kube-system.svc.cluster.local valid=30s;
-      proxy_http_version 1.1;
-      server {
-        listen 80;
-        location / {
-          proxy_pass https://marketplace.dify.ai;
-          proxy_set_header Host marketplace.dify.ai;
-          proxy_ssl_server_name on;
-          proxy_buffering on;
-        }
-      }
-    }
----
-apiVersion: apps/v1
-kind: Deployment
-metadata: {name: dify-marketplace-proxy, namespace: <ns>}
-spec:
-  replicas: 1
-  selector: {matchLabels: {app: dify-marketplace-proxy}}
-  template:
-    metadata: {labels: {app: dify-marketplace-proxy}}
-    spec:
-      containers:
-        - name: nginx
-          image: nginx:1.27-alpine
-          volumeMounts: [{name: cfg, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf}]
-      volumes: [{name: cfg, configMap: {name: dify-marketplace-proxy}}]
----
-apiVersion: v1
-kind: Service
-metadata: {name: dify-marketplace-proxy, namespace: <ns>}
-spec:
-  selector: {app: dify-marketplace-proxy}
-  ports: [{port: 80, targetPort: 80}]
-```
-
-### 6.2 PyPI reverse proxy
-
-Point at any PyPI mirror your cluster can reach (e.g. `https://mirrors.aliyun.com/pypi/simple/`). Use the same Nginx pattern as 6.1, or any PyPI cache such as [devpi](https://www.devpi.net/). Expose it as Service `dify-pip-proxy`.
-
-## Step 7 — Create the Dify Resource \{#create-the-dify-resource}
-
-### 7.1 Connection secrets
+### Create the connection secrets
 
 ```bash
 # DB / Redis / pgvector passwords are read from key `password`
 kubectl create secret generic dify-db       --from-literal=password='<db-password>'
 kubectl create secret generic dify-redis    --from-literal=password='<redis-password>'    # omit if Redis has no auth
 kubectl create secret generic dify-pgvector --from-literal=password='<pgvector-password>'
-
-# S3 only — keys must be `accessKey` and `secretKey`
+# S3 only — keys must be `accessKey` / `secretKey`
 kubectl create secret generic dify-s3 --from-literal=accessKey='<ak>' --from-literal=secretKey='<sk>'
 ```
 
-### 7.2 Minimal Dify resource
+### Fill in the form
+
+In **OperatorHub** → **Installed Operators**, select **Dify**, click **Create Dify**, and fill the form. The fields are grouped:
+
+- **Access** — set **Console URL** and **App URL** per the option chosen in Step 4 (same value for both in Options A and B; two different hostnames in Option C). Include the scheme (`http://` for NodePort, `https://` for Gateway).
+- **Database** — host, port, username (default `postgres`), database name, and the **DB Secret** (`dify-db`). Toggle **SSL** if your PostgreSQL requires it.
+- **Redis** — choose **Standalone** or **Sentinel**.
+  - *Standalone:* host, port, **Redis Secret** (leave empty if no auth).
+  - *Sentinel:* comma-separated `host:port` list, **Master name**, **Redis Secret**, and **Sentinel Secret** if Sentinel itself requires auth.
+- **Vector store (pgvector)** — toggle **Enable**. When enabled: host, port, username, database name, **Vector Secret**.
+- **Storage** — choose **PVC** or **S3**.
+  - *PVC:* the RWX StorageClass and size.
+  - *S3:* endpoint, region, **API bucket**, **Plugin bucket**, **S3 Secret** (`dify-s3`), and **Path-style addressing** (turn ON for MinIO and most S3-compatible endpoints; OFF for AWS).
+- **HTTP Route** — *only when using a Gateway (Option B or C).* Set **Gateway name**, **Gateway namespace**, optional **Section name** (listener), and **Hostnames** (must be covered by the Gateway listener).
+- **Advanced → Plugin proxy** — *only on restricted-network clusters.* Set **Marketplace** ON and fill **Marketplace URL** with the proxy from Step 5 (must be an FQDN). Fill **PIP Mirror URL**. Turn on **Ignore uv lock** (otherwise `uv sync --frozen` bypasses the mirror). Raise **Plugin init timeout** (e.g. `1200`s) for slow mirrors. Turn OFF **Verify plugin signature** if you serve repackaged plugins.
+
+The same settings as a YAML reference (for the form's YAML view):
 
 ```yaml
-# Browser-facing base URLs (no path suffix). Hostnames from Step 1.
 consoleUrl: https://dify-console.example.com
 appUrl:     https://dify-app.example.com
 
@@ -245,113 +174,65 @@ database:
   sslEnabled: false
 
 redis:
-  mode: standalone           # standalone | sentinel
+  mode: standalone               # standalone | sentinel
   host: <redis-host>
   port: 6379
-  secret: dify-redis         # omit if no auth
+  secret: dify-redis             # omit if no auth
   cacheDB: 0
   brokerDB: 1
 
 vectorStore:
-  enabled: true              # set false to disable RAG
+  enabled: true                  # set false to disable RAG
   host: <pgvector-host>
   port: 5432
   username: postgres
   name: dify_vector
   secret: dify-pgvector
 
-# Choose ONE of the storage blocks — RWX PVC or S3
 storage:
-  type: PVC                  # PVC | S3
+  type: PVC                      # PVC | S3
   storageClass: <rwx-storage-class>
   size: 20Gi
 
-# Production exposure via Gateway API — refers to the Gateway created in Step 5
-httpRoute:
+httpRoute:                       # Option B / C only
   gatewayName: dify
   gatewayNamespace: <gateway-namespace>
   hostnames:
     - dify-console.example.com
     - dify-app.example.com
-```
 
-### 7.3 Add-ons
-
-#### Redis Sentinel (HA) \{#redis-sentinel}
-
-```yaml
-redis:
-  mode: sentinel
-  sentinels: "<host1>:26379,<host2>:26379,<host3>:26379"
-  masterName: mymaster
-  secret: dify-redis             # Redis AUTH password, if any
-  sentinelSecret: dify-sentinel  # Sentinel AUTH password, if any
-```
-
-#### Storage on S3
-
-```yaml
-storage:
-  type: S3
-  endpoint: https://<s3-endpoint>   # e.g. http://minio.minio-system:9000 for MinIO
-  region: us-east-1
-  apiBucket: dify
-  pluginBucket: dify-plugin
-  s3Secret: dify-s3                 # keys: accessKey / secretKey
-  s3PathStyle: true                 # true for MinIO / most S3-compatible; false for AWS
-```
-
-#### Database SSL
-
-```yaml
-database:
-  sslEnabled: true
-```
-
-#### Restricted network — use the proxies from [Step 6](#proxies)
-
-```yaml
-proxy:
+proxy:                           # restricted network only
   marketplace: true
-  # FQDN required — the API's SSRF proxy (squid) cannot resolve short in-cluster names
   marketplaceURL: http://dify-marketplace-proxy.<ns>.svc.cluster.local
   pipMirrorUrl:   http://dify-pip-proxy.<ns>.svc.cluster.local/pypi/simple/
-  ignoreUvLock: true            # drop `uv sync --frozen` so plugin deps come from the PIP mirror
-  pluginInitTimeout: 1200       # raise from 120s default for slow mirrors
-  verifyPluginSignature: false  # allow repackaged / offline plugin packages
+  ignoreUvLock: true
+  pluginInitTimeout: 1200
+  verifyPluginSignature: false
 ```
 
-To disable the Marketplace entirely instead, set `proxy.marketplace: false` and install plugins via **Install via Local Package File** in the console. See [Dify: Installing the Plugin](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/release-by-file#installing-the-plugin).
+## Step 7 — Sign In
 
-#### NodePort exposure (no domain prep) \{#nodeport}
-
-Skip Steps 1 and 5. Expose the API and Web Services as NodePort (or use the platform's Service exposure UI), then set `consoleUrl` / `appUrl` to the reachable node address — for example `http://<node-ip>:<nodeport>`. Do not set `httpRoute`.
-
-## Step 8 — Access and Initial Setup
-
-1. Wait until the Dify resource reports its workloads `Ready`.
-2. Open `consoleUrl` in a browser; Dify will prompt for **initial admin setup** (email + password) on first sign-in.
+1. Wait until the Dify instance reports its workloads `Ready`.
+2. Open **Console URL** in a browser; Dify prompts for **initial admin setup** (email + password) on first sign-in.
 3. After signing in, create additional users from the console.
-4. Visit `appUrl` to confirm published-app access (you can publish a quick test app from the console to verify).
+4. Visit **App URL** to confirm published-app access (publish a quick test app from the console to verify).
 
-## Reference: Dify Resource Fields
+## Reference: Dify Instance Fields
 
-Top-level fields exposed by the Dify resource:
-
-| Field | Type | Purpose |
+| Field | Form group | Purpose |
 |---|---|---|
-| `consoleUrl` | string | Browser URL for the Console (builder UI). See [Why two URLs](#why-two-urls). |
-| `appUrl` | string | Browser URL for published apps. |
-| `database.{host, port, username, name, secret, sslEnabled}` | object | External PostgreSQL connection. `secret` holds key `password`. |
-| `redis.{mode, host, port, sentinels, masterName, secret, sentinelSecret, cacheDB, brokerDB, sslEnabled}` | object | External Redis. `mode = standalone | sentinel`. |
-| `vectorStore.{enabled, host, port, username, name, secret}` | object | pgvector. `enabled: false` disables RAG. |
-| `storage.{type, storageClass, size, endpoint, apiBucket, pluginBucket, s3Secret, region, s3PathStyle}` | object | `type = PVC | S3`. |
-| `httpRoute.{gatewayName, gatewayNamespace, sectionName, hostnames}` | object | Gateway API exposure. Omit for NodePort. |
-| `proxy.{marketplace, marketplaceURL, pipMirrorUrl, ignoreUvLock, pluginInitTimeout, verifyPluginSignature}` | object | Plugin install behavior for restricted networks. |
+| `consoleUrl` | Access | Browser URL for the builder UI |
+| `appUrl` | Access | Browser URL for published apps |
+| `database.{host, port, username, name, secret, sslEnabled}` | Database | External PostgreSQL connection. `secret` holds key `password`. |
+| `redis.{mode, host, port, sentinels, masterName, secret, sentinelSecret, cacheDB, brokerDB, sslEnabled}` | Redis | `mode = standalone | sentinel` |
+| `vectorStore.{enabled, host, port, username, name, secret}` | Vector store | pgvector |
+| `storage.{type, storageClass, size, endpoint, apiBucket, pluginBucket, s3Secret, region, s3PathStyle}` | Storage | `type = PVC | S3` |
+| `httpRoute.{gatewayName, gatewayNamespace, sectionName, hostnames}` | HTTP Route | Gateway API exposure; omit for NodePort |
+| `proxy.{marketplace, marketplaceURL, pipMirrorUrl, ignoreUvLock, pluginInitTimeout, verifyPluginSignature}` | Advanced — Plugin proxy | Restricted-network plugin install |
 
-Secret-key conventions:
+Secret key conventions:
 
-| Secret | Key(s) |
+| Secret field | Key(s) the Secret must contain |
 |---|---|
 | `database.secret` / `redis.secret` / `redis.sentinelSecret` / `vectorStore.secret` | `password` |
 | `storage.s3Secret` | `accessKey`, `secretKey` |

--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -4,7 +4,16 @@ weight: 20
 
 # Install Dify
 
-This document describes how to deploy Dify on a Kubernetes cluster using the **Dify Operator** (a helm-based OLM operator). You install the operator once, then create a **Dify** custom resource and configure it through the form (or YAML). The operator deploys the Dify workloads only — **PostgreSQL, Redis, and the vector store must be provided externally** and referenced from the Dify resource.
+This document describes how to deploy Dify on **Alauda Container Platform** using the **Dify Operator** (a helm-based OLM operator). The end-to-end flow is:
+
+1. **Publish** the Dify operator package to the platform repository (`violet push`).
+2. **Install the operator** from Marketplace / OperatorHub.
+3. **Prepare external dependencies** — PostgreSQL, Redis, optional pgvector, storage.
+4. **(For Gateway exposure)** install **Envoy Gateway** and create a `Gateway` resource that Dify will attach to.
+5. **(For restricted-network clusters)** deploy in-cluster reverse proxies for the **Dify Marketplace** and **PyPI**.
+6. **Create the Dify resource** and configure it.
+
+The operator deploys the Dify workloads only — PostgreSQL, Redis, and the vector store must be provided externally and referenced from the Dify resource.
 
 For an overview of Dify and its components, see [Introduction](overview/intro).
 
@@ -21,23 +30,39 @@ The operator runs the following Dify components as separate workloads:
 
 ## Prerequisites
 
-- Kubernetes 1.21+ (Gateway API CRDs installed if you expose Dify through a Gateway)
-- External **PostgreSQL 12+** (only PostgreSQL is supported for the main database)
-- External **Redis 6.0+** — **standalone or Sentinel (HA)**; Redis Cluster is not supported
-- For RAG: **PostgreSQL with the pgvector extension** (optional — can be disabled if you don't use RAG)
-- Storage for the API and Plugin Daemon: a **RWX** PersistentVolume StorageClass **or** an S3-compatible object store
+- **Alauda Container Platform** with a target cluster (Kubernetes 1.21+) and cluster-admin access.
+- External **PostgreSQL 12+** (only PostgreSQL is supported for the main database).
+- External **Redis 6.0+** — **standalone or Sentinel (HA)**; Redis Cluster is not supported.
+- For RAG: **PostgreSQL with the pgvector extension** (optional — can be disabled if you don't use RAG).
+- Storage for the API and Plugin Daemon: a **RWX** PersistentVolume StorageClass **or** an S3-compatible object store.
+- **For Gateway API exposure (recommended):** the **Gateway API CRDs** and a Gateway implementation (this guide uses **Envoy Gateway**).
+- **For restricted-network clusters:** in-cluster reverse proxies to the Dify Marketplace and to PyPI (see [Restricted network](#restricted-network)).
+
+## Publish the Operator Package
+
+The Dify operator is delivered as an installation package (e.g. `dify-operator.alpha.ALL.v<version>.tgz`). Publish it to the platform's local repository so it appears in **Marketplace / OperatorHub**:
+
+```bash
+violet push \
+  --platform-address=<platform-access-address> \
+  --platform-username=<platform-admin> \
+  --platform-password=<platform-admin-password> \
+  dify-operator.alpha.ALL.v<version>.tgz
+```
+
+After `violet push` succeeds, the operator becomes installable from the cluster's **Marketplace / OperatorHub** view.
 
 ## Install the Operator
 
-1. Sign in to **Alauda Container Platform** as an administrator.
-2. Open the cluster's **Marketplace / OperatorHub**, find **Dify**, and **Install** it into the target cluster.
-3. After the operator is running, create a **Dify** instance: select the target namespace and fill in the form (or switch to **YAML**). The sections below describe the fields. You can change them later by updating the Dify resource.
+1. Sign in to **Alauda Container Platform** as a cluster administrator.
+2. Open the target cluster's **Marketplace / OperatorHub**, find **Dify**, and **Install** it.
+3. After the operator is running you can create one or more **Dify** instances — see [Required Configuration](#required-configuration) and the optional sections.
 
 ## Prepare Dependencies
 
 ### PostgreSQL (required)
 
-Use **PostgreSQL 12+**. You can create a PostgreSQL cluster via the PostgreSQL operator in **Data Services** and obtain the host and credentials from the instance details. Create an empty database for Dify (e.g. `dify`).
+Use **PostgreSQL 12+**. You can create a PostgreSQL cluster via the **PostgreSQL operator in Data Services**, then read the host and credentials from the instance details. Create an empty database for Dify (e.g. `dify`).
 
 ### Redis (required — standalone or Sentinel)
 
@@ -55,7 +80,69 @@ Only **pgvector** is supported. Use a PostgreSQL instance with the pgvector exte
 The API and Plugin Daemon need shared, writable storage. Use either:
 
 - a **PVC** backed by a **ReadWriteMany (RWX)** StorageClass (the API, worker and worker-beat share it), or
-- an **S3-compatible** object store (recommended when no RWX class is available).
+- an **S3-compatible** object store (recommended when no RWX class is available; see [Storage — PVC (RWX) or S3](#storage)).
+
+## Set up the Gateway (for Gateway API exposure)
+
+If you want to expose Dify via Gateway API (recommended for production), install **Envoy Gateway** into the cluster **before** creating the Dify resource.
+
+### Install Envoy Gateway
+
+Install Envoy Gateway via its Helm chart (or via the Envoy Gateway operator if available in your Marketplace):
+
+```bash
+helm install eg oci://docker.io/envoyproxy/gateway-helm \
+  --version v1.2.4 \
+  --namespace envoy-gateway-system --create-namespace
+```
+
+Verify the controller is running:
+
+```bash
+kubectl -n envoy-gateway-system get pods
+kubectl get gatewayclass
+```
+
+You should see at least one `GatewayClass` named `eg` (or similar).
+
+### Create a Gateway resource
+
+Create a `Gateway` with the listeners Dify needs (one or two HTTPS listeners — for `consoleUrl` and `appUrl`, which can share a host or use separate hosts). The Dify resource's `httpRoute` will reference this Gateway by name.
+
+```yaml
+# TLS certificate for the listener
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dify-tls
+  namespace: <gateway-namespace>
+type: kubernetes.io/tls
+data:
+  tls.crt: <base64-cert>
+  tls.key: <base64-key>
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: dify
+  namespace: <gateway-namespace>
+spec:
+  gatewayClassName: eg                     # match the installed GatewayClass
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.example.com"            # or specific hosts
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - {name: dify-tls}
+      allowedRoutes:
+        namespaces:
+          from: All                        # allow HTTPRoutes from the Dify namespace
+```
+
+The Dify resource's `httpRoute.gatewayName` / `httpRoute.gatewayNamespace` / `httpRoute.hostnames` will reference this Gateway. Make sure `consoleUrl` / `appUrl` use the same hostnames so the browser reaches the right host.
 
 ## Required Configuration
 
@@ -68,7 +155,7 @@ kubectl create secret generic dify-redis    --from-literal=password='<redis-pass
 kubectl create secret generic dify-pgvector --from-literal=password='<pgvector-password>'
 ```
 
-Minimal Dify resource fields:
+Minimal Dify resource fields (form or YAML):
 
 ```yaml
 # Browser-facing base URLs (no path suffix) — required so the frontend loads correctly
@@ -150,24 +237,78 @@ storage:
   s3PathStyle: true                 # true for MinIO / most S3-compatible endpoints; false for AWS
 ```
 
-### Expose via Gateway API (HTTPRoute)
+### Expose via Gateway API (HTTPRoute) \{#httproute}
 
-Attach Dify to an existing Gateway:
+Attach Dify to the Gateway you set up in [Set up the Gateway](#set-up-the-gateway-for-gateway-api-exposure):
 
 ```yaml
 httpRoute:
-  gatewayName: <gateway-name>
+  gatewayName: dify
   gatewayNamespace: <gateway-namespace>
-  sectionName: <listener-name>       # optional; the Gateway listener to bind
+  sectionName: https                 # optional; the Gateway listener to bind
   hostnames:
     - <dify.example.com>
 ```
 
-Make sure `consoleUrl` / `appUrl` match the hostnames so the browser reaches the right host.
+Make sure `consoleUrl` / `appUrl` match the hostnames.
 
-### Restricted network (internal plugin installation)
+### Restricted network \{#restricted-network}
 
-When the cluster cannot reach public PyPI / the Dify Marketplace (`https://marketplace.dify.ai`), install plugins through an in-cluster **Marketplace reverse proxy + PIP mirror**:
+When the cluster cannot reach the public Dify Marketplace (`https://marketplace.dify.ai`) or PyPI, install plugins through **in-cluster reverse proxies**.
+
+#### Deploy a Marketplace reverse proxy
+
+The upstream requires `Host: marketplace.dify.ai`. A minimal Nginx proxy:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: dify-marketplace-proxy, namespace: <ns>}
+data:
+  nginx.conf: |
+    events {}
+    http {
+      resolver kube-dns.kube-system.svc.cluster.local valid=30s;
+      proxy_http_version 1.1;
+      server {
+        listen 80;
+        location / {
+          proxy_pass https://marketplace.dify.ai;
+          proxy_set_header Host marketplace.dify.ai;
+          proxy_ssl_server_name on;
+          proxy_buffering on;
+        }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: {name: dify-marketplace-proxy, namespace: <ns>}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: dify-marketplace-proxy}}
+  template:
+    metadata: {labels: {app: dify-marketplace-proxy}}
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          volumeMounts: [{name: cfg, mountPath: /etc/nginx/nginx.conf, subPath: nginx.conf}]
+      volumes: [{name: cfg, configMap: {name: dify-marketplace-proxy}}]
+---
+apiVersion: v1
+kind: Service
+metadata: {name: dify-marketplace-proxy, namespace: <ns>}
+spec:
+  selector: {app: dify-marketplace-proxy}
+  ports: [{port: 80, targetPort: 80}]
+```
+
+#### Deploy a PIP mirror proxy (optional)
+
+Either point at a public mirror reachable from the cluster (e.g. `https://mirrors.aliyun.com/pypi/simple/`) or stand up a similar Nginx reverse proxy to it. For a self-hosted PyPI cache, [devpi](https://www.devpi.net/) is also an option.
+
+#### Configure Dify to use the proxies
 
 ```yaml
 proxy:
@@ -180,7 +321,9 @@ proxy:
   verifyPluginSignature: false  # allow repackaged / offline plugin packages
 ```
 
-- `marketplaceURL` must be a reverse proxy to `https://marketplace.dify.ai` (the upstream requires `Host: marketplace.dify.ai`), and must be an **FQDN** — the SSRF proxy cannot resolve short in-cluster names.
+Important notes:
+
+- `marketplaceURL` must be an **FQDN** — the SSRF proxy cannot resolve short in-cluster names.
 - By default plugin installs run `uv sync --frozen`, which pins PyPI and **bypasses** `pipMirrorUrl`. Set `ignoreUvLock: true` so plugin Python dependencies are fetched from the mirror.
 - To disable the marketplace entirely instead, set `proxy.marketplace: false` and install plugins via **Install via Local Package File** in the console. See [Dify: Installing the Plugin](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/release-by-file#installing-the-plugin).
 

--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -17,7 +17,7 @@ For what Dify is and the components it deploys, see [Introduction](overview/intr
 | External **Redis 6+** (standalone or Sentinel) | Cache + Celery broker; Cluster mode is **not** supported |
 | External **pgvector** *(optional)* | Vector store for RAG; disable if not using RAG |
 | **RWX PVC** *or* **S3-compatible storage** | Shared, writable storage for API + Plugin Daemon |
-| An **access method** for browsers | One of: NodePort/Service, single domain, or two domains. See [Step 4](#access-method) |
+| An **access method** for browsers | One of: NodePort/Service, single domain, or two domains. Domains and TLS certs are registered through ACP **Network Management**. See [Step 4](#access-method) |
 | **In-cluster proxies** *(restricted-network only)* | A Marketplace reverse proxy + a PyPI mirror so plugins install offline |
 
 ## Step 1 — Publish the Operator Package
@@ -78,46 +78,57 @@ Both URLs must match how users actually reach Dify, otherwise the frontend canno
 | Option | When to use | What to prepare | Console URL / App URL |
 |---|---|---|---|
 | **A. NodePort / Service IP** | Dev / internal; no domain | Nothing | Both set to `http://<node-ip>:<nodeport>` (one address used for both) |
-| **B. Single domain** | One hostname for both surfaces | 1 DNS record + 1 TLS cert; an Envoy Gateway instance + Gateway resource | Both set to `https://<host>` |
-| **C. Two domains** | Production — separate admin vs end-user access (different DNS / cert / network exposure) | 2 DNS records + TLS cert(s); an Envoy Gateway instance + Gateway resource | Console URL = `https://<console-host>`, App URL = `https://<app-host>` |
+| **B. Single domain** | One hostname for both surfaces | 1 ACP Certificate + 1 ACP Domain; Envoy Gateway + a `Gateway` resource | Both set to `https://<host>` |
+| **C. Two domains** | Production — separate admin vs end-user access (different DNS / cert / network exposure) | 1 ACP Certificate (can cover both, e.g. wildcard) + 2 ACP Domains; Envoy Gateway + a `Gateway` resource | Console URL = `https://<console-host>`, App URL = `https://<app-host>` |
 
 For **Option A** there is nothing to set up here — go to Step 5. For **Options B and C**, set up the Gateway as follows.
 
 ### Set Up the Gateway (Option B or C only)
 
+Three sub-steps: register the certificate and domain in ACP → install Envoy Gateway → create a `Gateway` resource that references the certificate Secret.
+
+#### 1. Register the certificate and domain in ACP
+
+ACP provides UI flows to import TLS certificates and register domain names; both are reused by the `Gateway` resource you create below.
+
+1. **Import the certificate** — in **Administrator** view, go to **Network Management** → **Certificates** → **Create Certificate**. Paste **Public Key** (`tls.crt`) + **Private Key** (`tls.key`) and assign it to the target project. ACP stores it as a TLS Secret in the cluster. Full instructions: <ExternalSiteLink name="acp" href="/networking/functions/configure_certificate.mdx" children="Creating Certificates" />.
+2. **Register the domain** — go to **Network Management** → **Domain Names** → **Create Domain Name**. Pick **Type** (Domain or Wildcard Domain), enter your hostname (e.g. `dify-console.example.com`), allocate it to the target cluster + project, and bind the certificate created above (or paste the cert inline; ACP will create a per-domain Secret named `<domain>-<random>`). Full instructions: <ExternalSiteLink name="acp" href="/networking/functions/configure_domain.mdx" children="Configure Domain" />.
+3. **Note the Secret name** — open the Domain detail page and copy the bound Secret's name. The `Gateway` listener references this Secret by name in step 3 below.
+4. **Resolve DNS** — register the domain (if not already) and point it at the cluster's load balancer address.
+
+Repeat for the second hostname under Option C (two domains).
+
+#### 2. Install Envoy Gateway
+
 ACP includes the **Alauda Build of Envoy Gateway** operator. If it isn't installed yet, install it from **Marketplace / OperatorHub** — see <ExternalSiteLink name="acp" href="/networking/operators/envoy_gateway_operator.mdx" children="install_envoy_gateway_operator" />.
 
-Then prepare a TLS Secret and create a `Gateway` resource. The Dify instance's HTTP Route will reference this Gateway in Step 6.
+#### 3. Create the `Gateway` resource
 
-```bash
-kubectl create secret tls dify-tls \
-  --cert=tls.crt --key=tls.key \
-  -n <gateway-namespace>
-```
+Reference the Secret name(s) you noted in sub-step 1. The Dify instance's HTTP Route will reference this Gateway by name in Step 6.
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: dify
-  namespace: <gateway-namespace>
+  namespace: <gateway-namespace>          # same namespace as the cert Secret(s)
 spec:
-  gatewayClassName: <envoy-gateway-class>    # the GatewayClass exposed by Envoy Gateway
+  gatewayClassName: <envoy-gateway-class> # the GatewayClass exposed by Envoy Gateway
   listeners:
     - name: https
       protocol: HTTPS
       port: 443
-      hostname: "*.example.com"               # cover both console + app hostnames
+      hostname: "*.example.com"           # cover all hostnames registered in sub-step 1
       tls:
         mode: Terminate
         certificateRefs:
-          - {name: dify-tls}
+          - {name: <secret-name-from-ACP-domain>}  # name copied from the Domain detail page
       allowedRoutes:
         namespaces:
           from: All
 ```
 
-Point DNS for each hostname at the Gateway's external address (`kubectl get gateway dify -n <gateway-namespace> -o wide`).
+For Option C with two different hosts on the same Gateway, add a second listener (each listener can point at its own `hostname` and `certificateRefs`).
 
 ## Step 5 — Provide Plugin-Install Proxies *(restricted network only)*
 

--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -4,15 +4,16 @@ weight: 20
 
 # Install Dify
 
-This document describes how to deploy Dify to a Kubernetes cluster using the Helm chart and common configuration. For an overview of Dify and its components, see [Introduction](overview/intro). The chart deploys Dify components only; PostgreSQL, Redis, and the vector store must be provided externally and configured in values.
+This document describes how to deploy Dify on a Kubernetes cluster using the **Dify Operator** (a helm-based OLM operator). You install the operator once, then create a **Dify** custom resource and configure it through the form (or YAML). The operator deploys the Dify workloads only — **PostgreSQL, Redis, and the vector store must be provided externally** and referenced from the Dify resource.
 
-## Overview
+For an overview of Dify and its components, see [Introduction](overview/intro).
 
-The chart runs the following components as separate workloads:
+## Components
+
+The operator runs the following Dify components as separate workloads:
 
 - **API** – Backend API and business logic
-- **Worker** – Celery workers for async tasks
-- **Worker Beat** – Celery beat for scheduled tasks
+- **Worker** / **Worker Beat** – Celery workers and scheduler for async/scheduled tasks
 - **Web** – Frontend UI
 - **Plugin Daemon** – Plugin runtime
 - **Sandbox** – Isolated code execution
@@ -20,238 +21,174 @@ The chart runs the following components as separate workloads:
 
 ## Prerequisites
 
-- Kubernetes 1.19+
-- Ingress controller (e.g. nginx-ingress-controller) when exposing via Ingress
-- External PostgreSQL 12+ (this chart only supports PostgreSQL)
-- External Redis 6.0+ (standalone only; Sentinel and Cluster are not supported)
-- For RAG: PostgreSQL with pgvector extension, or set `vectorStore.type: ""` to disable
+- Kubernetes 1.21+ (Gateway API CRDs installed if you expose Dify through a Gateway)
+- External **PostgreSQL 12+** (only PostgreSQL is supported for the main database)
+- External **Redis 6.0+** — **standalone or Sentinel (HA)**; Redis Cluster is not supported
+- For RAG: **PostgreSQL with the pgvector extension** (optional — can be disabled if you don't use RAG)
+- Storage for the API and Plugin Daemon: a **RWX** PersistentVolume StorageClass **or** an S3-compatible object store
 
-## Downloading
+## Install the Operator
 
-Download the Dify installation file: `dify.ALL.xxxx.tgz`
+1. Sign in to **Alauda Container Platform** as an administrator.
+2. Open the cluster's **Marketplace / OperatorHub**, find **Dify**, and **Install** it into the target cluster.
+3. After the operator is running, create a **Dify** instance: select the target namespace and fill in the form (or switch to **YAML**). The sections below describe the fields. You can change them later by updating the Dify resource.
 
-Use the violet command to publish to the platform repository:
+## Prepare Dependencies
 
-```bash
-violet push --platform-address=platform-access-address --platform-username=platform-admin --platform-password=platform-admin-password dify.ALL.xxxx.tgz
-```
+### PostgreSQL (required)
 
-## Deployment
+Use **PostgreSQL 12+**. You can create a PostgreSQL cluster via the PostgreSQL operator in **Data Services** and obtain the host and credentials from the instance details. Create an empty database for Dify (e.g. `dify`).
 
-### Prepare Database
+### Redis (required — standalone or Sentinel)
 
-Use **PostgreSQL 12+**. The chart only supports PostgreSQL. You can create a PostgreSQL cluster via the PostgreSQL operator in **Data Services** and obtain the host and credentials from the instance details.
+Use **Redis 6.0+**. You can create a Redis instance via **Data Services**.
 
-### Prepare Redis
+- **Standalone:** when creating the instance, select **Redis Sentinel** for Architecture, switch to **YAML**, set `spec.arch` to `standalone`, then create. The read-write Service is `rfr-<instance>-read-write`.
+- **Sentinel (HA):** keep the Sentinel architecture; use the Sentinel Service endpoints and master name (see [Redis Sentinel (HA)](#redis-sentinel-ha)).
 
-Use **Redis 6.0+** in **standalone** mode only (Sentinel and Cluster are not supported). You can create a Redis instance via **Data Services**. To use standalone mode:
+### Vector store / pgvector (optional, for RAG)
 
-1. When creating the instance, select **Redis Sentinel** for Architecture.
-2. Switch to **YAML** mode, set `spec.arch` to `standalone`, then create.
-3. After creation, in **Alauda Container Platform** find the Service named `rfr-<Redis instance name>-read-write` for the Redis host.
+Only **pgvector** is supported. Use a PostgreSQL instance with the pgvector extension (the same host as the main database with a different database name, or a dedicated host). If you do not use RAG, set `vectorStore.enabled: false`.
 
-### Prepare Vector Store (for RAG)
+### Storage (RWX PVC or S3)
 
-This chart supports **pgvector** only. Use a PostgreSQL instance with the pgvector extension (can be the same host as the main database with a different database name, or a dedicated host). If you do not use RAG, set `vectorStore.type: ""` and omit pgvector.
+The API and Plugin Daemon need shared, writable storage. Use either:
 
-### Prepare Storage (optional)
-
-The cluster should have CSI or pre-created PersistentVolumes if you use PVC for API and plugin storage. By default the chart uses PVC; you can override `storageClass`, `size`, and `accessMode` in values, or use S3-compatible object storage instead (see [Storage (S3 and PVC)](#storage-s3-and-pvc)).
-
-### Create Application
-
-1. In **Alauda Container Platform**, select the namespace where Dify will be deployed.
-2. Go to **Applications** / **Applications**, click **Create**.
-3. Choose **Create from Catalog** and go to the **Catalog** view.
-4. Find **3rdparty/chart-dify** and click **Create**.
-5. Enter **Name** (e.g. `dify`) and configure **Custom** values as below, then create. You can change values later via **Update** on the application.
+- a **PVC** backed by a **ReadWriteMany (RWX)** StorageClass (the API, worker and worker-beat share it), or
+- an **S3-compatible** object store (recommended when no RWX class is available).
 
 ## Required Configuration
 
-You must configure at least:
-
-1. **URLs** – `urls.consoleUrl` and `urls.appUrl` (base URLs for browser access, no path suffix; required for the app to open correctly)
-2. **Database** – PostgreSQL 12+ (host and credentials via Secret)
-3. **Redis** – Redis 6.0+ standalone (host and credentials via Secret)
-4. **Vector store** – pgvector (host and credentials via Secret), or set `vectorStore.type: ""` to disable
-
-### Minimal Required Values
-
-Create the secrets (replace placeholders with your values):
+Create the connection secrets (the **key names must match** what the operator reads):
 
 ```bash
-kubectl create secret generic dify-db-secret --from-literal=password='<db-password>'
-kubectl create secret generic dify-redis-secret --from-literal=password='<redis-password>'
-kubectl create secret generic dify-pgvector-secret --from-literal=password='<pgvector-password>'
+# DB / Redis / pgvector passwords are read from key `password`
+kubectl create secret generic dify-db       --from-literal=password='<db-password>'
+kubectl create secret generic dify-redis    --from-literal=password='<redis-password>'    # omit if Redis has no auth
+kubectl create secret generic dify-pgvector --from-literal=password='<pgvector-password>'
 ```
 
-Minimal Custom Values (fill in your hosts and secret names):
+Minimal Dify resource fields:
 
 ```yaml
-# Required: base URLs for console and app (no path suffix)
-urls:
-  consoleUrl: <https://console-domain>   # or http://
-  appUrl: <https://app-domain>           # or http://
+# Browser-facing base URLs (no path suffix) — required so the frontend loads correctly
+consoleUrl: https://<console-host>
+appUrl: https://<app-host>
 
-# Required: main database (PostgreSQL 12+)
 database:
-  host: <postgres-host-without-port>
-  secret:
-    name: <dify-db-secret>
-  # Optional: enable when PostgreSQL uses SSL
-  # ssl:
-  #   enabled: true
+  host: <postgres-host>      # host only, no port
+  port: 5432
+  username: postgres
+  name: dify
+  secret: dify-db            # Secret holding key `password`
+  sslEnabled: false
 
-# Required: Redis 6.0+ (standalone only)
 redis:
-  host: <redis-host-without-port>
-  secret:
-    name: <dify-redis-secret>
+  mode: standalone           # standalone | sentinel
+  host: <redis-host>
+  port: 6379
+  secret: dify-redis         # optional; omit if Redis has no auth
+  cacheDB: 0
+  brokerDB: 1
 
-# Required: vector store (pgvector; or set vectorStore.type: "" to disable)
 vectorStore:
-  pgvector:
-    host: <pgvector-host-without-port>
-    secret:
-      name: <dify-pgvector-secret>
-
-# If your cluster has no default StorageClass, configure storage.*.pvc.storageClass
-# storage:
-#   api:
-#     pvc:
-#       storageClass: <storage-class>
-#   plugin:
-#     pvc:
-#       storageClass: <storage-class>
+  enabled: true              # set false to disable RAG / pgvector
+  host: <pgvector-host>
+  port: 5432
+  username: postgres
+  name: dify_vector
+  secret: dify-pgvector
 ```
 
 ## Optional Configuration
 
-### Database (SSL)
+### Redis Sentinel (HA) \{#redis-sentinel-ha}
 
-When PostgreSQL requires SSL connection, enable it:
+Both the cache and the Celery broker run over Sentinel:
+
+```yaml
+redis:
+  mode: sentinel
+  sentinels: "<host1>:26379,<host2>:26379,<host3>:26379"
+  masterName: mymaster
+  secret: dify-redis            # Redis AUTH password (key `password`), if any
+  sentinelSecret: dify-sentinel # Sentinel AUTH password (key `password`), if any
+```
+
+### Database SSL
 
 ```yaml
 database:
-  ssl:
-    enabled: true
+  sslEnabled: true
 ```
 
-### Vector store (disable)
+### Storage — PVC (RWX) or S3 \{#storage}
 
-When not using RAG/vector search:
-
-```yaml
-vectorStore:
-  type: ""
-```
-
-### Ingress (host and TLS)
-
-By default `ingress.enabled` is true and `ingress.hosts[].host` can be empty (match all domains). Set a hostname and TLS when needed:
-
-```yaml
-ingress:
-  className: <ingress-class>
-  hosts:
-    - host: <dify.example.com>
-  tls:
-    - secretName: <dify-tls>
-      hosts:
-        - <dify.example.com>
-```
-
-### Storage (S3 and PVC) \{#storage-s3-and-pvc}
-
-**PVC (default):** API and plugin daemon each use a PVC when enabled. Override storage class and size as needed.
-
-If your cluster has no default StorageClass, `storageClass` is required for each PVC:
+**PVC (RWX):**
 
 ```yaml
 storage:
-  api:
-    type: opendal
-    pvc:
-      enabled: true
-      size: 10Gi
-      storageClass: <storage-class>
-      accessMode: ReadWriteOnce
-  plugin:
-    type: local
-    pvc:
-      enabled: true
-      size: 10Gi
-      storageClass: <storage-class>
-      accessMode: ReadWriteOnce
+  type: PVC
+  storageClass: <rwx-storage-class>
+  size: 20Gi
 ```
 
-**S3 (object storage):** Use Amazon S3 or another S3-compatible object store for API and/or plugin. Create a Secret with `ACCESS_KEY` and `SECRET_KEY` (or configure custom keys in values):
+**S3 / S3-compatible:** create a Secret with keys `accessKey` and `secretKey`:
 
 ```bash
-kubectl create secret generic <dify-s3-secret> --from-literal=ACCESS_KEY='<access-key>' --from-literal=SECRET_KEY='<secret-key>'
+kubectl create secret generic dify-s3 --from-literal=accessKey='<ak>' --from-literal=secretKey='<sk>'
 ```
 
 ```yaml
 storage:
-  api:
-    type: s3
-    s3:
-      endpoint: <s3-endpoint>   # empty for AWS default; for custom endpoints e.g. https://object-storage.example.com:9000
-      region: <region>
-      bucket: <bucket>
-      addressStyle: path   # "path" for many S3-compatible endpoints; "virtual" for AWS
-      secret:
-        name: <dify-s3-secret>
-  plugin:
-    type: s3
-    s3:
-      endpoint: <s3-endpoint>
-      region: <region>
-      bucket: <bucket>
-      secret:
-        name: <dify-s3-secret>
+  type: S3
+  endpoint: https://<s3-endpoint>   # e.g. http://minio.minio-system:9000 for MinIO
+  region: us-east-1
+  apiBucket: dify
+  pluginBucket: dify-plugin
+  s3Secret: dify-s3                 # keys: accessKey / secretKey
+  s3PathStyle: true                 # true for MinIO / most S3-compatible endpoints; false for AWS
 ```
 
-### PIP install mirror (proxy)
+### Expose via Gateway API (HTTPRoute)
 
-When the cluster cannot access PyPI (e.g. offline or restricted network), set a PIP index URL for **Plugin Daemon** (plugin dependencies) and/or **Sandbox** (code execution):
+Attach Dify to an existing Gateway:
 
 ```yaml
-pluginDaemon:
-  pipMirrorUrl: "<mirror-url>"   # e.g. https://mirrors.aliyun.com/pypi/simple/
-
-sandbox:
-  pipMirrorUrl: "<mirror-url>"
+httpRoute:
+  gatewayName: <gateway-name>
+  gatewayNamespace: <gateway-namespace>
+  sectionName: <listener-name>       # optional; the Gateway listener to bind
+  hostnames:
+    - <dify.example.com>
 ```
 
-For a simple self-hosted PyPI proxy you can use [devpi](https://devpi.net/); then set `pipMirrorUrl` to that proxy URL (e.g. `http://<host>:3141/root/pypi/+simple/`).
+Make sure `consoleUrl` / `appUrl` match the hostnames so the browser reaches the right host.
 
-### Marketplace (internal network)
+### Restricted network (internal plugin installation)
 
-When the cluster cannot reach the public marketplace (`https://marketplace.dify.ai`):
-
-**Option 1 – Disable marketplace:** Install plugins via "Install via Local Package File" in the console. See [Dify: Installing the Plugin](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/release-by-file#installing-the-plugin).
+When the cluster cannot reach public PyPI / the Dify Marketplace (`https://marketplace.dify.ai`), install plugins through an in-cluster **Marketplace reverse proxy + PIP mirror**:
 
 ```yaml
-api:
-  marketplace:
-    enabled: false
+proxy:
+  marketplace: true
+  # FQDN required — the API's SSRF proxy (squid) cannot resolve short in-cluster names
+  marketplaceURL: http://dify-marketplace-proxy.<ns>.svc.cluster.local
+  pipMirrorUrl: http://dify-pip-proxy.<ns>.svc.cluster.local/pypi/simple/
+  ignoreUvLock: true            # drop `uv sync --frozen` so plugin deps resolve via the PIP mirror
+  pluginInitTimeout: 1200       # raise from the 120s default for slow mirrors
+  verifyPluginSignature: false  # allow repackaged / offline plugin packages
 ```
 
-**Option 2 – Internal marketplace proxy:** Deploy a reverse proxy to `https://marketplace.dify.ai` (the upstream requires `Host: marketplace.dify.ai`) and set:
-
-```yaml
-api:
-  marketplace:
-    enabled: true
-    url: <https://internal-marketplace.example.com>
-```
+- `marketplaceURL` must be a reverse proxy to `https://marketplace.dify.ai` (the upstream requires `Host: marketplace.dify.ai`), and must be an **FQDN** — the SSRF proxy cannot resolve short in-cluster names.
+- By default plugin installs run `uv sync --frozen`, which pins PyPI and **bypasses** `pipMirrorUrl`. Set `ignoreUvLock: true` so plugin Python dependencies are fetched from the mirror.
+- To disable the marketplace entirely instead, set `proxy.marketplace: false` and install plugins via **Install via Local Package File** in the console. See [Dify: Installing the Plugin](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/release-by-file#installing-the-plugin).
 
 ## Access
 
-- **Via Ingress:** If Ingress is enabled and a host is set, use `https://<host>` (or the configured `urls.consoleUrl` / `urls.appUrl`) to open the console and app.
-- **Via Service:** Otherwise use the API and Web Services (e.g. NodePort or LoadBalancer) as exposed by the chart; ensure `urls.consoleUrl` and `urls.appUrl` match how users reach the app so the frontend loads correctly.
+- **Via Gateway:** open `consoleUrl` (builder UI) and `appUrl` (published apps) once the HTTPRoute is Accepted.
+- **Via Service / NodePort:** expose the API and Web Services and set `consoleUrl` / `appUrl` to the reachable address (for example `http://<node-ip>:<nodeport>`); the host in these URLs must match how users actually reach Dify, otherwise the frontend will not load.
 
 ## User Management
 
-Dify has no default admin password. Complete initial setup and create users (e.g. email/password) from the login or sign-up page after the application is running.
+Dify has no default admin. After the instance is running, open `consoleUrl` and complete the initial admin setup (email + password) on the first sign-in, then create additional users from the console.

--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -286,9 +286,9 @@ proxy:                           # restricted network only
 | `consoleUrl` | Access | Browser URL for the builder UI |
 | `appUrl` | Access | Browser URL for published apps |
 | `database.{host, port, username, name, secret, sslEnabled}` | Database | External PostgreSQL connection. `secret` holds key `password`. |
-| `redis.{mode, host, port, sentinels, masterName, secret, sentinelSecret, cacheDB, brokerDB, sslEnabled}` | Redis | `mode = standalone | sentinel` |
+| `redis.{mode, host, port, sentinels, masterName, secret, sentinelSecret, cacheDB, brokerDB, sslEnabled}` | Redis | `mode = standalone` or `sentinel` |
 | `vectorStore.{enabled, host, port, username, name, secret}` | Vector store | pgvector |
-| `storage.{type, storageClass, size, endpoint, apiBucket, pluginBucket, s3Secret, region, s3PathStyle}` | Storage | `type = PVC | S3` |
+| `storage.{type, storageClass, size, endpoint, apiBucket, pluginBucket, s3Secret, region, s3PathStyle}` | Storage | `type = PVC` or `S3` |
 | `httpRoute.{gatewayName, gatewayNamespace, sectionName, hostnames}` | HTTP Route | Gateway API exposure; omit for NodePort |
 | `proxy.{marketplace, marketplaceURL, pipMirrorUrl, ignoreUvLock, pluginInitTimeout, verifyPluginSignature}` | Advanced — Plugin proxy | Restricted-network plugin install |
 

--- a/docs/en/dify/install.mdx
+++ b/docs/en/dify/install.mdx
@@ -85,18 +85,29 @@ For **Option A** there is nothing to set up here — go to Step 5. For **Options
 
 ### Set Up the Gateway (Option B or C only)
 
-Three sub-steps: register the certificate and domain in ACP → install Envoy Gateway → create a `Gateway` resource that references the certificate Secret.
+Three sub-steps: register the domain (with its cert) in ACP → install Envoy Gateway → create a `Gateway` resource that references the cert Secret.
 
-#### 1. Register the certificate and domain in ACP
+#### 1. Register the domain in ACP
 
-ACP provides UI flows to import TLS certificates and register domain names; both are reused by the `Gateway` resource you create below.
+In **Administrator** view, go to **Network Management** → **Domain Names** → **Create Domain Name**, and fill the form:
 
-1. **Import the certificate** — in **Administrator** view, go to **Network Management** → **Certificates** → **Create Certificate**. Paste **Public Key** (`tls.crt`) + **Private Key** (`tls.key`) and assign it to the target project. ACP stores it as a TLS Secret in the cluster. Full instructions: <ExternalSiteLink name="acp" href="/networking/functions/configure_certificate.mdx" children="Creating Certificates" />.
-2. **Register the domain** — go to **Network Management** → **Domain Names** → **Create Domain Name**. Pick **Type** (Domain or Wildcard Domain), enter your hostname (e.g. `dify-console.example.com`), allocate it to the target cluster + project, and bind the certificate created above (or paste the cert inline; ACP will create a per-domain Secret named `<domain>-<random>`). Full instructions: <ExternalSiteLink name="acp" href="/networking/functions/configure_domain.mdx" children="Configure Domain" />.
-3. **Note the Secret name** — open the Domain detail page and copy the bound Secret's name. The `Gateway` listener references this Secret by name in step 3 below.
-4. **Resolve DNS** — register the domain (if not already) and point it at the cluster's load balancer address.
+| Field | Value |
+|---|---|
+| **Type** | Domain (specific hostname) or Wildcard Domain (`*.example.com`) |
+| **Domain** | The hostname, e.g. `dify-console.example.com` |
+| **Allocate Cluster** | Target cluster + project (or all projects) |
+| **Certificate** | Paste **Public Key** (`tls.crt`) and **Private Key** (`tls.key`) directly into the form — ACP creates the bound TLS Secret automatically |
 
-Repeat for the second hostname under Option C (two domains).
+ACP creates:
+
+- a `Domain` custom resource on the global cluster (`apiVersion: crd.alauda.io/v2`, cluster-scoped, with `cluster.cpaas.io/name` / `project.cpaas.io/name` labels);
+- a `kubernetes.io/tls` Secret in the **`cpaas-system`** namespace named **`<domain>-<random>`** (e.g. `dify-console.example.com-xfd8x`); the Domain's `cpaas.io/secret-ref` annotation records this name.
+
+You can find the Secret name from the Domain detail page. Full UI reference: <ExternalSiteLink name="acp" href="/networking/functions/configure_domain.mdx" children="Configure Domain" />.
+
+Then **resolve DNS** for the hostname to the cluster's load balancer address.
+
+Repeat for the second hostname under Option C (two domains). One certificate that covers both hosts (e.g. a wildcard) can be reused — paste the same cert in both Domain forms, or use **Network Management** → **Certificates** to import the cert once and select it during domain creation (see <ExternalSiteLink name="acp" href="/networking/functions/configure_certificate.mdx" children="Creating Certificates" />).
 
 #### 2. Install Envoy Gateway
 
@@ -104,14 +115,19 @@ ACP includes the **Alauda Build of Envoy Gateway** operator. If it isn't install
 
 #### 3. Create the `Gateway` resource
 
-Reference the Secret name(s) you noted in sub-step 1. The Dify instance's HTTP Route will reference this Gateway by name in Step 6.
+Reference the cert Secret(s) from sub-step 1. Because those Secrets live in **`cpaas-system`** and a Gateway listener's `certificateRefs` only resolves Secrets in the Gateway's own namespace by default, you have two equivalent options:
+
+- **Simpler — put the Gateway in `cpaas-system`** so it can name the Secrets directly.
+- **Cross-namespace — keep the Gateway in its own namespace** and add a `ReferenceGrant` in `cpaas-system` allowing your Gateway namespace to reference Secrets there.
+
+**Option a — Gateway in `cpaas-system`:**
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: dify
-  namespace: <gateway-namespace>          # same namespace as the cert Secret(s)
+  namespace: cpaas-system                 # co-located with the cert Secrets
 spec:
   gatewayClassName: <envoy-gateway-class> # the GatewayClass exposed by Envoy Gateway
   listeners:
@@ -122,10 +138,45 @@ spec:
       tls:
         mode: Terminate
         certificateRefs:
-          - {name: <secret-name-from-ACP-domain>}  # name copied from the Domain detail page
+          - {name: <secret-name-from-ACP-domain>}   # from the Domain detail page
       allowedRoutes:
         namespaces:
           from: All
+```
+
+**Option b — Gateway in another namespace, with `ReferenceGrant`:**
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: dify
+  namespace: <gateway-namespace>
+spec:
+  gatewayClassName: <envoy-gateway-class>
+  listeners:
+    - name: https
+      protocol: HTTPS
+      port: 443
+      hostname: "*.example.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - {namespace: cpaas-system, name: <secret-name-from-ACP-domain>}
+      allowedRoutes:
+        namespaces:
+          from: All
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: dify-tls
+  namespace: cpaas-system                 # grant lives in the Secret's namespace
+spec:
+  from:
+    - {group: gateway.networking.k8s.io, kind: Gateway, namespace: <gateway-namespace>}
+  to:
+    - {group: "", kind: Secret}            # could also restrict by name
 ```
 
 For Option C with two different hosts on the same Gateway, add a second listener (each listener can point at its own `hostname` and `certificateRefs`).


### PR DESCRIPTION
## Summary

Rewrite `docs/en/dify/install.mdx` to match the actual **Dify Operator** we deliver (v1.15.0), instead of the generic Helm-chart install the previous version described.

The existing doc referenced `3rdparty/chart-dify` and a values structure (`urls.consoleUrl`, `pluginDaemon.pipMirrorUrl`, `api.marketplace.url`, `storage.api.s3`, Ingress, etc.) that does not match the Dify Operator's CR spec. Users following it would not find the correct fields/install path.

## What changed

- **Install path**: OperatorHub → install the Dify Operator → create a Dify CR (form / YAML), not "Catalog → 3rdparty/chart-dify".
- **CR field names** aligned with the operator's actual spec (top-level `consoleUrl`/`appUrl`; flat `storage.*`; `redis.mode` standalone/sentinel; `httpRoute.*` for Gateway API; `proxy.*` for marketplace + PIP mirror).
- **Redis Sentinel (HA)** is supported — corrected the "standalone only" claim.
- **Secret key conventions** documented (`password` for DB/Redis/pgvector; `accessKey`/`secretKey` for S3).
- **Restricted network** section updated to the verified flow: **Marketplace reverse proxy + PIP mirror + `proxy.ignoreUvLock: true`** (plus `verifyPluginSignature: false` / raised `pluginInitTimeout`). The old doc only mentioned offline local package install.

## Test plan

- [ ] Render `docs/en/dify/install.mdx` and verify MDX renders cleanly (`weight: 20` frontmatter, anchor links `#redis-sentinel-ha` / `#storage`).
- [ ] Spot-check the YAML examples against an actual Dify CR / operator chart values (every key matches the operator's spec).
- [ ] Verify external links (Dify upstream install-the-plugin doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
