### PR TITLE
docs(inference_guide): validated DeepSeek-V4-Flash (W8A8) on Ascend 910B3 (16-card DP2×TP8 + mooncake KV store)

### DIFF
--- a/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml
+++ b/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml
@@ -12,11 +12,26 @@
 # replicas=1: the two DP ranks are the leader (rank 0) and worker (rank 1) of one
 # LeaderWorkerSet, NOT two independent replicas (replicas:2 would halve the ctx).
 #
-# Model source: ModelScope `Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp` (70 shards, ~280 GB).
-# Unlike the other models in this guide there is NO public Docker Hub ModelCar for this
-# W8A8 variant — the weights are pre-downloaded to a node-local PVC on EACH node (rank 0
-# mounts the copy on node 0, rank 1 the copy on node 1). Repoint the two claims below at
-# wherever you stage the weights.
+# Model source: ModelScope `Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp` (70 shards, ~280 GB),
+# repackaged as an Alauda ModelCar in OCI Image Layout format (multi-arch amd64+arm64):
+#   http://package-minio.alauda.cn:9199/packages/aml-models-oci/v0.1.0/DeepSeek-V4-Flash-w8a8-mtp.oci.tar
+# The cluster pulls an OCI *image*, not the tar, so import the archive into your own
+# registry once (skopeo does the multi-arch push in one shot), then point model.uri at it:
+#   skopeo copy --all \
+#     oci-archive:DeepSeek-V4-Flash-w8a8-mtp.oci.tar:v0.1.0 \
+#     docker://<your-registry>/modelcar-deepseek-v4-flash-w8a8-mtp:v0.1.0
+#   # v0.1.0 = the tag inside index.json; confirm with:
+#   #   tar -xO -f DeepSeek-V4-Flash-w8a8-mtp.oci.tar index.json \
+#   #     | jq -r '.manifests[0].annotations["org.opencontainers.image.ref.name"]'
+# With model.uri = oci://…, InferNex/KServe runs a storageInitializer that pulls the
+# ModelCar to /mnt/models in EACH DP rank's pod (leader on node 0, worker on node 1), so
+# each node needs ~280 GB+ free ephemeral space.
+#   ALT (what the docs benchmark actually used): stage the weights on a node-local PVC per
+#   node and skip the pull — set `spec.model.uri: pvc://<node0-pvc>/` +
+#   `spec.storageInitializer.enabled: false`, and add back a `model` volume
+#   (persistentVolumeClaim) + `/mnt/models` volumeMount on BOTH the leader (node-0 PVC) and
+#   worker (node-1 PVC). The ModelCar is the same weights; the DP2 cross-node
+#   storageInitializer pull path was not separately re-run for this model.
 #
 # agg-mc-kv = the validated graph config PLUS a mooncake KV store shared by the two DP
 # ranks. DP2 random routing scatters each user's growing history across the two ranks,
@@ -49,9 +64,9 @@
 # Ingress: benchmarked through the product **MaaS gateway** (OpenAI-compatible, API-key
 # auth) as well as the internal KServe ingress — see the page for both curl forms.
 #
-# Before applying: set the namespace `demo`, repoint the two node-local PVC claims at
-# your staged weights, and make sure both nodes can pull the engine + hermes-router
-# images (air-gapped nodes need them pre-loaded).
+# Before applying: set the namespace `demo`, import the ModelCar and set model.uri to your
+# registry (or use the node-local PVC ALT above), and make sure both nodes can pull the
+# engine + hermes-router images (air-gapped nodes need them pre-loaded).
 # =============================================================================
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceService
@@ -68,13 +83,14 @@ metadata:
 spec:
   model:
     name: deepseek-v4-flash-w8a8      # == --served-model-name == MaaS modelName == client -m
-    uri: pvc://dsv4-n8/               # node-local weights (no public ModelCar for W8A8)
+    # Import the OCI ModelCar tar into your registry first (see header); the
+    # storageInitializer then pulls it to /mnt/models in each DP rank. For the
+    # node-local PVC ALT (what the benchmark used), see the header block.
+    uri: oci://<your-registry>/modelcar-deepseek-v4-flash-w8a8-mtp:v0.1.0
   replicas: 1                         # ONE aggregated service (leader + worker below) = 16 cards
   parallelism:
     data: 2                           # DP2 across the two nodes
     dataLocal: 1                      # 1 DP rank per node
-  storageInitializer:
-    enabled: false
   # ===== router: hermes-router (EPP), random-picker. DP2 has one leader endpoint, so
   #       random is effectively a no-op, but the structure is kept for consistency. =====
   router:
@@ -289,15 +305,19 @@ spec:
         httpGet: { path: /health, port: http }
         periodSeconds: 30
       volumeMounts:
-      - { mountPath: /mnt/models, name: model, readOnly: true }
+      # /mnt/models is provided by the storageInitializer (ModelCar pull). For the PVC ALT
+      # (see header) add: - { mountPath: /mnt/models, name: model, readOnly: true }
       - { mountPath: /dev/shm, name: shm }
       - { mountPath: /app, name: mooncake-config, readOnly: true }   # read the mooncake.json the initContainer wrote
     hostIPC: true
+    imagePullSecrets:
+    - { name: modelcar-registry-auth }   # only needed if <your-registry> is private
     tolerations:
     - operator: Exists
     volumes:
-    - name: model
-      persistentVolumeClaim: { claimName: dsv4-n8 }   # node-0 weights PVC
+    # For the PVC ALT (see header) add here:
+    #   - name: model
+    #     persistentVolumeClaim: { claimName: <node-0 weights PVC> }
     - name: shm
       emptyDir: { medium: Memory, sizeLimit: 32Gi }
     - name: mooncake-config
@@ -417,15 +437,19 @@ spec:
         failureThreshold: 160
         periodSeconds: 30
       volumeMounts:
-      - { mountPath: /mnt/models, name: model, readOnly: true }
+      # /mnt/models is provided by the storageInitializer (ModelCar pull). For the PVC ALT
+      # (see header) add: - { mountPath: /mnt/models, name: model, readOnly: true }
       - { mountPath: /dev/shm, name: shm }
       - { mountPath: /app, name: mooncake-config, readOnly: true }   # read the mooncake.json the initContainer wrote
     hostIPC: true
+    imagePullSecrets:
+    - { name: modelcar-registry-auth }   # only needed if <your-registry> is private
     tolerations:
     - operator: Exists
     volumes:
-    - name: model
-      persistentVolumeClaim: { claimName: dsv4-n9 }   # node-1 weights PVC
+    # For the PVC ALT (see header) add here:
+    #   - name: model
+    #     persistentVolumeClaim: { claimName: <node-1 weights PVC> }
     - name: shm
       emptyDir: { medium: Memory, sizeLimit: 32Gi }
     - name: mooncake-config

--- a/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml
+++ b/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml
@@ -1,0 +1,432 @@
+# DeepSeek-V4-Flash (W8A8) — agg-mc-kv aggregation on Alauda AI's InferNex surface:
+# KServe `LLMInferenceService` + InferNex-Bridge + hermes-router, DP2 × TP=8 across
+# TWO nodes (16 cards) with a mooncake cross-rank KV store. This is the EXACT shape
+# deployed and benchmarked on 2 × 8 × Ascend 910B3 (64 GB/card).
+#
+# DeepSeek-V4-Flash is the `deepseek_v4` architecture: 256-expert MoE + MLA + DSA
+# sparse attention + MTP, served here as W8A8 (W8A8_DYNAMIC int8 attn+expert,
+# ~280 GB weights, 70 shards, 43 layers). At ~280 GB the weights do not fit a single
+# 8 × 32 GB node, so this variant runs a single aggregated service spanning TWO 64 GB
+# nodes as **DP2 × TP=8 + EP16** (~280 GB / 16 ≈ 20.6 GB/card — very comfortable on
+# 64 GB cards, leaving room for a 200k-token KV pool). It is a SINGLE service with
+# replicas=1: the two DP ranks are the leader (rank 0) and worker (rank 1) of one
+# LeaderWorkerSet, NOT two independent replicas (replicas:2 would halve the ctx).
+#
+# Model source: ModelScope `Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp` (70 shards, ~280 GB).
+# Unlike the other models in this guide there is NO public Docker Hub ModelCar for this
+# W8A8 variant — the weights are pre-downloaded to a node-local PVC on EACH node (rank 0
+# mounts the copy on node 0, rank 1 the copy on node 1). Repoint the two claims below at
+# wherever you stage the weights.
+#
+# agg-mc-kv = the validated graph config PLUS a mooncake KV store shared by the two DP
+# ranks. DP2 random routing scatters each user's growing history across the two ranks,
+# so per-rank local multi-turn hit is only ~41%; the mooncake store lets a rank pull
+# prefix KV the other rank already computed, lifting merged effective prefix reuse to
+# ~84% (measured, S2 conc 8/16/32 × 480). vs a mooncake-free graph build that is
+# TTFT −24…44% / decode throughput +24…67%, ctx 200k intact, 0 error.
+#   NOTE: the store writes asynchronously (~30–60 s to land a 21k prefix). Cross-rank
+#   hits land for multi-turn agent sessions with >~1 min turn gaps; back-to-back
+#   sub-second reuse only hits the same rank's local prefix cache.
+#
+# Router = hermes-router (EPP) with the `random` picker and cache-indexer OFF: a single
+# aggregated endpoint needs no global KV index / KV-cache-aware routing — this matches
+# the GLM-5.2 / Qwen3-8B aggregation paradigm (mooncake store shares KV; router stays
+# random). Disabling only cache-indexer/pd-orchestrator/eagle-eye lets InferNex-Bridge
+# reconcile the mooncake-master + redis backends for the store.
+#
+# Prefix-cache hit gate on deepseek_v4 (ALL required, miss any → 0% hit): (1)
+# --enable-prefix-caching, (2) additional-config enable_dsa_cp:true, (3)
+# VLLM_ASCEND_ENABLE_FLASHCOMM1=1 (DSA-CP hard-depends on sequence parallel; without it
+# EngineCore crashes "DSA CP requires SP"), (4) VLLM_PREFIX_CACHE_RETENTION_INTERVAL=16384
+# (DSA sliding-window sparse checkpoint granularity; a prefix shorter than this has no
+# reusable checkpoint). decode graph = FULL_DECODE_ONLY (MTP keeps enforce_eager for the
+# draft head only). Requires the nightly-main image carrying the DP2 cross-node graph +
+# DSA-CP prefix-cache fixes (PIECEWISE graph is still unsupported for deepseek_v4).
+#
+# Image: quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709 (vLLM 0.23.0). Match
+# the tag's CANN version to your host NPU driver; the two nodes must have it locally.
+#
+# Ingress: benchmarked through the product **MaaS gateway** (OpenAI-compatible, API-key
+# auth) as well as the internal KServe ingress — see the page for both curl forms.
+#
+# Before applying: set the namespace `demo`, repoint the two node-local PVC claims at
+# your staged weights, and make sure both nodes can pull the engine + hermes-router
+# images (air-gapped nodes need them pre-loaded).
+# =============================================================================
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: deepseek-v4-flash-w8a8-agg-mc-kv
+  namespace: demo
+  labels:
+    infernex.io/runtime: "true"          # triggers InferNex-Bridge reconcile
+  annotations:
+    # agg-mc-kv: dropping "mooncake" from disabled-components makes InferNex-Bridge
+    # reconcile the mooncake-master + redis-service backends. cache-indexer stays OFF
+    # (a single aggregated endpoint needs no global KV index / KV-aware routing).
+    infernex.io/disabled-components: "cache-indexer,pd-orchestrator,eagle-eye"
+spec:
+  model:
+    name: deepseek-v4-flash-w8a8      # == --served-model-name == MaaS modelName == client -m
+    uri: pvc://dsv4-n8/               # node-local weights (no public ModelCar for W8A8)
+  replicas: 1                         # ONE aggregated service (leader + worker below) = 16 cards
+  parallelism:
+    data: 2                           # DP2 across the two nodes
+    dataLocal: 1                      # 1 DP rank per node
+  storageInitializer:
+    enabled: false
+  # ===== router: hermes-router (EPP), random-picker. DP2 has one leader endpoint, so
+  #       random is effectively a no-op, but the structure is kept for consistency. =====
+  router:
+    gateway: {}
+    route: {}
+    scheduler:
+      pool:
+        spec:
+          endpointPickerRef:
+            failureMode: FailOpen
+            group: ""
+            kind: Service
+            name: deepseek-v4-flash-w8a8-agg-mc-kv-epp-service
+            port:
+              number: 9002
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: deepseek-v4-flash-w8a8-agg-mc-kv
+              app.kubernetes.io/part-of: llminferenceservice
+              kserve.io/component: workload
+              leaderworkerset.sigs.k8s.io/worker-index: "0"   # target the DP leader (rank 0)
+          targetPorts:
+          - number: 8000
+      template:
+        containers:
+        - args:
+          - --pool-name
+          - deepseek-v4-flash-w8a8-agg-mc-kv-inference-pool
+          - --pool-namespace
+          - demo
+          - --pool-group
+          - inference.networking.k8s.io
+          - --zap-encoder
+          - json
+          - --v
+          - "1"
+          - --tracing
+          - "false"
+          - --metrics-endpoint-auth
+          - "false"
+          - --config-text
+          - |-
+            apiVersion: inference.networking.x-k8s.io/v1alpha1
+            kind: EndpointPickerConfig
+            plugins:
+            - type: metrics-data-source
+              parameters: { scheme: "http", path: "/metrics", insecureSkipVerify: true }
+            - type: core-metrics-extractor
+            - type: random-picker
+            schedulingProfiles:
+            - name: default
+              plugins:
+              - pluginRef: random-picker
+          image: build-harbor.alauda.cn/3rdparty/openfuyao/hermes-router:26.6.0-rc.3
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            grpc: { port: 9003, service: liveness }
+            periodSeconds: 10
+            timeoutSeconds: 5
+          name: main
+          ports:
+          - { containerPort: 9002, name: grpc, protocol: TCP }
+          - { containerPort: 9003, name: grpc-health, protocol: TCP }
+          - { containerPort: 9090, name: metrics, protocol: TCP }
+          readinessProbe:
+            failureThreshold: 3
+            grpc: { port: 9003, service: readiness }
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            limits: { memory: 4Gi }
+            requests: { cpu: "1", memory: 1Gi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile: { type: RuntimeDefault }
+          startupProbe:
+            failureThreshold: 30
+            grpc: { port: 9003, service: liveness }
+            periodSeconds: 10
+            timeoutSeconds: 5
+          volumeMounts:
+          - { mountPath: /etc/ssl/certs, name: tls-certs, readOnly: true }
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        serviceAccountName: deepseek-v4-flash-w8a8-agg-mc-kv-epp-sa
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: tls-certs
+          secret:
+            secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
+  # ===== leader (DP rank 0, node 0, mounts the node-0 weights PVC) =====
+  template:
+    initContainers:
+    # Write /app/mooncake.json — tells the in-engine mooncake client where the store is
+    # (local_hostname = this pod IP; master/redis are reconciled by InferNex-Bridge).
+    - name: mooncake-config-init
+      image: quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-c"]
+      args:
+      - |
+        set -e
+        cat > /app/mooncake.json <<EOF
+        {"local_hostname":"${POD_IP:-0.0.0.0}","metadata_server":"redis://redis-service:6379","master_server_address":"mooncake-master-service:30089","device_name":"","protocol":"ascend","global_segment_size":42949672960,"use_ascend_direct":true}
+        EOF
+        echo "[mooncake-config-init] wrote /app/mooncake.json:"; cat /app/mooncake.json
+      env:
+      - name: POD_IP
+        valueFrom: { fieldRef: { fieldPath: status.podIP } }
+      volumeMounts:
+      - { name: mooncake-config, mountPath: /app }
+    containers:
+    - args:
+      - |
+        set +e   # a fresh-start getent lookup can transiently fail; set -e would crash bash immediately
+        source /usr/local/Ascend/ascend-toolkit/set_env.sh 2>/dev/null || true
+        source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true
+        for _i in $(seq 1 60); do DP_ADDR=$(getent hosts "${LWS_LEADER_ADDRESS}" 2>/dev/null | awk '{print $1}' | head -1); [ -n "${DP_ADDR:-}" ] && break; echo "[dsv4] waiting LWS_LEADER_ADDRESS dns ($_i)"; sleep 2; done
+        DP_ADDR=${DP_ADDR:-${LWS_LEADER_ADDRESS}}
+        echo "[dsv4-leader] HCCL_IF_IP=${HCCL_IF_IP} DP_ADDR=${DP_ADDR} devices=$(ls /dev/davinci* 2>/dev/null | tr '\n' ' ')"
+        export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"   # ascend_transport.so (mooncake store transport)
+        exec vllm serve /mnt/models \
+          --host 0.0.0.0 --port 8000 \
+          --served-model-name deepseek-v4-flash-w8a8 \
+          --seed 1024 \
+          --trust-remote-code \
+          --api-server-count 1 \
+          --kv-transfer-config '{"engine_id":"$(POD_NAME)","kv_connector":"AscendStoreConnector","kv_role":"kv_both","kv_port":"20000","kv_connector_extra_config":{"backend":"mooncake","decode":{"dp_size":2,"tp_size":8},"prefill":{"dp_size":2,"tp_size":8},"lookup_rpc_port":"1"}}' \
+          --data-parallel-size 2 \
+          --data-parallel-size-local 1 \
+          --data-parallel-address ${DP_ADDR} \
+          --data-parallel-rpc-port 13389 \
+          --tensor-parallel-size 8 \
+          --enable-expert-parallel \
+          --quantization ascend \
+          --tokenizer-mode deepseek_v4 \
+          --tool-call-parser deepseek_v4 \
+          --enable-auto-tool-choice \
+          --reasoning-parser deepseek_v4 \
+          --max-model-len 200000 \
+          --max-num-batched-tokens 8192 \
+          --max-num-seqs 32 \
+          --gpu-memory-utilization 0.92 \
+          --block-size 128 \
+          --safetensors-load-strategy 'prefetch' \
+          --model-loader-extra-config '{"enable_multithread_load":"true","num_threads":128}' \
+          --async-scheduling \
+          --enable-prefix-caching \
+          --speculative-config '{"num_speculative_tokens":1,"method":"mtp","enforce_eager":true}' \
+          --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+          --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"enable_dsa_cp":true,"multistream_overlap_shared_expert":true}'
+      command: ["/bin/bash", "-c"]
+      env:
+      - { name: HOME, value: /home }
+      - { name: VLLM_LOGGING_LEVEL, value: INFO }
+      - { name: HF_HUB_OFFLINE, value: "1" }
+      - { name: HCCL_OP_EXPANSION_MODE, value: AIV }
+      - { name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL, value: "16384" }   # deepseek_v4 prefix-cache hit prerequisite
+      - { name: VLLM_ASCEND_ENABLE_FLASHCOMM1, value: "1" }              # enable_dsa_cp hard-depends on SP; also a cross-node comm optimization
+      - name: HCCL_IF_IP
+        valueFrom: { fieldRef: { fieldPath: status.podIP } }
+      - { name: GLOO_SOCKET_IFNAME, value: eth0 }
+      - { name: TP_SOCKET_IFNAME, value: eth0 }
+      - { name: HCCL_SOCKET_IFNAME, value: eth0 }
+      - { name: VLLM_RPC_TIMEOUT, value: "360000" }
+      - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "3000" }
+      - { name: HCCL_EXEC_TIMEOUT, value: "200" }
+      - { name: HCCL_CONNECT_TIMEOUT, value: "120" }
+      - { name: OMP_PROC_BIND, value: "false" }
+      - { name: OMP_NUM_THREADS, value: "10" }
+      - { name: PYTORCH_NPU_ALLOC_CONF, value: expandable_segments:True }
+      - { name: ACL_OP_INIT_MODE, value: "1" }
+      - { name: TASK_QUEUE_ENABLE, value: "1" }
+      - { name: CPU_AFFINITY_CONF, value: "1" }
+      - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "1200" }
+      # --- mooncake KV store (agg-mc-kv: shared prefix KV across the two DP ranks) ---
+      - { name: PYTHONHASHSEED, value: "0" }                    # identical cross-pod block hashes (store key match; unset → 0 hit)
+      - { name: MOONCAKE_CONFIG_PATH, value: /app/mooncake.json }
+      - { name: HCCL_WHITELIST_DISABLE, value: "1" }
+      - { name: HCCL_INTRA_ROCE_ENABLE, value: "1" }           # cross-pod KV transfer over NIC RoCE/RDMA
+      - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }   # unique engine_id (store participant id)
+      - { name: POD_IP,   valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+      image: quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 8
+        httpGet: { path: /health, port: http }
+        periodSeconds: 15
+        timeoutSeconds: 10
+      name: main
+      ports:
+      - { containerPort: 8000, name: http, protocol: TCP }
+      readinessProbe:
+        failureThreshold: 3
+        httpGet: { path: /health, port: http }
+        periodSeconds: 10
+      resources:
+        limits: { cpu: "48", huawei.com/Ascend910: "8", memory: 480Gi }
+        requests: { cpu: "16", huawei.com/Ascend910: "8", memory: 96Gi }
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+        seccompProfile: { type: RuntimeDefault }
+      startupProbe:
+        failureThreshold: 160     # ~280 GB from PVC + init: budget ~80 min
+        httpGet: { path: /health, port: http }
+        periodSeconds: 30
+      volumeMounts:
+      - { mountPath: /mnt/models, name: model, readOnly: true }
+      - { mountPath: /dev/shm, name: shm }
+      - { mountPath: /app, name: mooncake-config, readOnly: true }   # read the mooncake.json the initContainer wrote
+    hostIPC: true
+    tolerations:
+    - operator: Exists
+    volumes:
+    - name: model
+      persistentVolumeClaim: { claimName: dsv4-n8 }   # node-0 weights PVC
+    - name: shm
+      emptyDir: { medium: Memory, sizeLimit: 32Gi }
+    - name: mooncake-config
+      emptyDir: {}
+  # ===== worker (DP rank 1, node 1, mounts the node-1 weights PVC) =====
+  worker:
+    initContainers:
+    - name: mooncake-config-init
+      image: quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-c"]
+      args:
+      - |
+        set -e
+        cat > /app/mooncake.json <<EOF
+        {"local_hostname":"${POD_IP:-0.0.0.0}","metadata_server":"redis://redis-service:6379","master_server_address":"mooncake-master-service:30089","device_name":"","protocol":"ascend","global_segment_size":42949672960,"use_ascend_direct":true}
+        EOF
+        echo "[mooncake-config-init] wrote /app/mooncake.json:"; cat /app/mooncake.json
+      env:
+      - name: POD_IP
+        valueFrom: { fieldRef: { fieldPath: status.podIP } }
+      volumeMounts:
+      - { name: mooncake-config, mountPath: /app }
+    containers:
+    - args:
+      - |
+        set +e
+        source /usr/local/Ascend/ascend-toolkit/set_env.sh 2>/dev/null || true
+        source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true
+        for _i in $(seq 1 60); do DP_ADDR=$(getent hosts "${LWS_LEADER_ADDRESS}" 2>/dev/null | awk '{print $1}' | head -1); [ -n "${DP_ADDR:-}" ] && break; echo "[dsv4] waiting LWS_LEADER_ADDRESS dns ($_i)"; sleep 2; done
+        DP_ADDR=${DP_ADDR:-${LWS_LEADER_ADDRESS}}
+        echo "[dsv4-worker] HCCL_IF_IP=${HCCL_IF_IP} DP_ADDR=${DP_ADDR} devices=$(ls /dev/davinci* 2>/dev/null | tr '\n' ' ')"
+        export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH:-}"   # ascend_transport.so (mooncake store transport)
+        exec vllm serve /mnt/models \
+          --host 0.0.0.0 --port 8000 \
+          --headless \
+          --served-model-name deepseek-v4-flash-w8a8 \
+          --seed 1024 \
+          --trust-remote-code \
+          --data-parallel-size 2 \
+          --data-parallel-size-local 1 \
+          --data-parallel-start-rank 1 \
+          --kv-transfer-config '{"engine_id":"$(POD_NAME)","kv_connector":"AscendStoreConnector","kv_role":"kv_both","kv_port":"20000","kv_connector_extra_config":{"backend":"mooncake","decode":{"dp_size":2,"tp_size":8},"prefill":{"dp_size":2,"tp_size":8},"lookup_rpc_port":"1"}}' \
+          --data-parallel-address ${DP_ADDR} \
+          --data-parallel-rpc-port 13389 \
+          --tensor-parallel-size 8 \
+          --enable-expert-parallel \
+          --quantization ascend \
+          --tokenizer-mode deepseek_v4 \
+          --tool-call-parser deepseek_v4 \
+          --enable-auto-tool-choice \
+          --reasoning-parser deepseek_v4 \
+          --max-model-len 200000 \
+          --max-num-batched-tokens 8192 \
+          --max-num-seqs 32 \
+          --gpu-memory-utilization 0.92 \
+          --block-size 128 \
+          --safetensors-load-strategy 'prefetch' \
+          --model-loader-extra-config '{"enable_multithread_load":"true","num_threads":128}' \
+          --async-scheduling \
+          --enable-prefix-caching \
+          --speculative-config '{"num_speculative_tokens":1,"method":"mtp","enforce_eager":true}' \
+          --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+          --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"enable_dsa_cp":true,"multistream_overlap_shared_expert":true}'
+      command: ["/bin/bash", "-c"]
+      env:
+      - { name: HOME, value: /home }
+      - { name: VLLM_LOGGING_LEVEL, value: INFO }
+      - { name: HF_HUB_OFFLINE, value: "1" }
+      - { name: HCCL_OP_EXPANSION_MODE, value: AIV }
+      - { name: VLLM_PREFIX_CACHE_RETENTION_INTERVAL, value: "16384" }   # deepseek_v4 prefix-cache hit prerequisite
+      - { name: VLLM_ASCEND_ENABLE_FLASHCOMM1, value: "1" }              # enable_dsa_cp hard-depends on SP; also a cross-node comm optimization
+      - name: HCCL_IF_IP
+        valueFrom: { fieldRef: { fieldPath: status.podIP } }
+      - { name: GLOO_SOCKET_IFNAME, value: eth0 }
+      - { name: TP_SOCKET_IFNAME, value: eth0 }
+      - { name: HCCL_SOCKET_IFNAME, value: eth0 }
+      - { name: VLLM_RPC_TIMEOUT, value: "360000" }
+      - { name: VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS, value: "3000" }
+      - { name: HCCL_EXEC_TIMEOUT, value: "200" }
+      - { name: HCCL_CONNECT_TIMEOUT, value: "120" }
+      - { name: OMP_PROC_BIND, value: "false" }
+      - { name: OMP_NUM_THREADS, value: "10" }
+      - { name: PYTORCH_NPU_ALLOC_CONF, value: expandable_segments:True }
+      - { name: ACL_OP_INIT_MODE, value: "1" }
+      - { name: TASK_QUEUE_ENABLE, value: "1" }
+      - { name: CPU_AFFINITY_CONF, value: "1" }
+      - { name: VLLM_ENGINE_READY_TIMEOUT_S, value: "1200" }
+      # --- mooncake KV store (agg-mc-kv: shared prefix KV across the two DP ranks) ---
+      - { name: PYTHONHASHSEED, value: "0" }                    # identical cross-pod block hashes (store key match; unset → 0 hit)
+      - { name: MOONCAKE_CONFIG_PATH, value: /app/mooncake.json }
+      - { name: HCCL_WHITELIST_DISABLE, value: "1" }
+      - { name: HCCL_INTRA_ROCE_ENABLE, value: "1" }           # cross-pod KV transfer over NIC RoCE/RDMA
+      - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }   # unique engine_id (store participant id)
+      - { name: POD_IP,   valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+      image: quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        exec: { command: ["bash", "-c", "pgrep -f 'vllm serve' >/dev/null"] }
+        failureThreshold: 6
+        periodSeconds: 30
+        timeoutSeconds: 10
+      name: main
+      ports:
+      - { containerPort: 13389, name: dp-rpc, protocol: TCP }
+      resources:
+        limits: { cpu: "48", huawei.com/Ascend910: "8", memory: 480Gi }
+        requests: { cpu: "16", huawei.com/Ascend910: "8", memory: 96Gi }
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsGroup: 0
+        runAsNonRoot: false
+        runAsUser: 0
+        seccompProfile: { type: RuntimeDefault }
+      startupProbe:
+        exec: { command: ["bash", "-c", "pgrep -f 'vllm serve' >/dev/null"] }
+        failureThreshold: 160
+        periodSeconds: 30
+      volumeMounts:
+      - { mountPath: /mnt/models, name: model, readOnly: true }
+      - { mountPath: /dev/shm, name: shm }
+      - { mountPath: /app, name: mooncake-config, readOnly: true }   # read the mooncake.json the initContainer wrote
+    hostIPC: true
+    tolerations:
+    - operator: Exists
+    volumes:
+    - name: model
+      persistentVolumeClaim: { claimName: dsv4-n9 }   # node-1 weights PVC
+    - name: shm
+      emptyDir: { medium: Memory, sizeLimit: 32Gi }
+    - name: mooncake-config
+      emptyDir: {}

--- a/docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx
+++ b/docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx
@@ -127,13 +127,43 @@ curl -s http://<maas-gateway>/v1/chat/completions \
 
 ## Benchmark results
 
-Closed-loop `aiperf`, **DP2 × TP=8 (16 × 910B3 64 GB)**, agg-mc-kv, driven through the
-product **MaaS gateway**. Two scenarios — ① 8k system-prompt reuse and ② 17.5k
-multi-turn — each swept at **concurrency 8 / 16 / 32**, 480 requests per tier (all tiers
-0 error / 0 mismatch). TTFT / E2E in s, ITL in ms; decode = output-only tok/s (measured),
-TPS = total tokens/s (input + output, computed).
+Closed-loop `aiperf 0.7.0`, **DP2 × TP=8 (16 × 910B3 64 GB)**, driven through the product
+**MaaS gateway**. Concurrency sweep **8 / 16 / 32**, 480 requests per tier (all tiers
+0 error / 0 mismatch). The headline numbers are the **production `agg-mc-kv`
+configuration** — FULL_DECODE_ONLY graph + mooncake cross-rank KV store, the exact config
+the manifest above deploys — on scenario ② (multi-turn nested long context), the
+agent-style workload the store targets. TTFT / E2E in s, ITL in ms; decode = output-only
+tok/s (measured), TPS = total tokens/s (input + output, computed; prefill-dominated).
 
-**Scenario ① — fixed-length system-prompt reuse (ISL ~8k / OSL 128)**
+**Scenario ② — multi-turn dialogue, production `agg-mc-kv` (ISL ~17.5k / OSL 128)**
+
+| Concurrency | TTFT avg (s) | ITL avg (ms) | E2E avg (s) | Decode (tok/s) | TPS (in+out) |
+|--:|--:|--:|--:|--:|--:|
+| 8  | 1.76 | 72  | 10.9 | 93.6  | 13198 |
+| 16 | 1.36 | 90  | 12.8 | 159.3 | 22467 |
+| 32 | 1.94 | 123 | 17.6 | 230.9 | **32559** |
+
+The mooncake cross-rank KV store is what makes this fast: it lifts multi-turn prefix
+reuse from ~41 % (per-rank local) to ~84 % (merged effective). Stepping the same
+scenario ② at concurrency 32 through the configs the deployment evolved from shows where
+the gain comes from:
+
+**Config evolution — Scenario ②, concurrency 32**
+
+| Config | TTFT avg (s) | E2E avg (s) | Decode (tok/s) | TPS (in+out) |
+|---|--:|--:|--:|--:|
+| agg (base — eager, no store) | 10.2 | 83.7 | 48.1 | 6781 |
+| + FULL_DECODE_ONLY graph | 3.2 | 29.3 | 138.7 | 19554 |
+| **+ mooncake KV store (production)** | **1.9** | **17.6** | **230.9** | **32559** |
+
+→ graph + store together are **TTFT ~5.3× / E2E ~4.8× / TPS ~4.8×** better than the base
+aggregation at the same concurrency.
+
+**Scenario ① — fixed-length system-prompt reuse (ISL ~8k / OSL 128), base agg**
+
+The 8k fixed-prompt scenario was measured only on the **base aggregation** config (graph
++ mooncake were not separately re-run for it), so treat these as a lower bound — the
+production config would lift them much like scenario ②:
 
 | Concurrency | TTFT avg (s) | ITL avg (ms) | E2E avg (s) | Decode (tok/s) | TPS (in+out) |
 |--:|--:|--:|--:|--:|--:|
@@ -141,26 +171,16 @@ TPS = total tokens/s (input + output, computed).
 | 16 | 3.42 | 350 | 47.8 | 42.3 | 2689 |
 | 32 | 5.71 | 493 | 68.3 | 59.2 | 3759 |
 
-**Scenario ② — multi-turn dialogue (ISL ~17.5k / OSL 128)**
-
-| Concurrency | TTFT avg (s) | ITL avg (ms) | E2E avg (s) | Decode (tok/s) | TPS (in+out) |
-|--:|--:|--:|--:|--:|--:|
-| 8  | 6.06 | 356 | 51.3 | 19.9 | 2802 |
-| 16 | 7.53 | 459 | 65.8 | 30.9 | 4357 |
-| 32 | 10.17 | 579 | 83.7 | 48.1 | 6781 |
-
 :::note
 **How to read these.** Every tier completed 480/480 with zero errors and zero output
 mismatches. As concurrency rises, **system throughput (decode / TPS) climbs**
-(sub-linear, saturating) while **TTFT / ITL / E2E also climb** — the queueing cost of
-more in-flight requests. This is a **prefill-heavy** workload (ISL 8k / 17.5k, OSL 128),
-so aggregate prefill throughput (~1600 tok/s at the 8k tier) dominates and latency is
-naturally high. The mooncake KV store is what lifts multi-turn prefix reuse from ~41 %
-(per-rank local) to ~84 % (merged effective), worth roughly **TTFT −24…44 % / decode
-throughput +24…67 %** versus a mooncake-free graph build.
+(sub-linear, saturating) while tail latency (TTFT / ITL / E2E) also climbs — the queueing
+cost of more in-flight requests. TPS is the **total-token (input + output)** caliber and
+is prefill-dominated (ISL 8k / 17.5k, OSL 128); the decode-only output rate is the
+separate "Decode" column.
 
-These numbers are **not directly comparable** to the other models in this guide: this is
-a concurrency sweep (not the fixed concurrency-4 run the Qwen models use), on **910B3
-64 GB** cards (not 910B4 32 GB), with a **16-card DP2 × TP=8** topology. Treat them as
-the operating envelope of this specific large-MoE deployment, not a cross-model ranking.
+These numbers are **not directly comparable** to the other models in this guide: it is a
+concurrency sweep (not the fixed concurrency-4 run the Qwen models use), on **910B3 64 GB**
+cards (not 910B4 32 GB), with a **16-card DP2 × TP=8** topology. Treat them as the
+operating envelope of this specific large-MoE deployment, not a cross-model ranking.
 :::

--- a/docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx
+++ b/docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx
@@ -26,13 +26,15 @@ sweep (8 / 16 / 32).
 | Architecture | `deepseek_v4` — 256-expert MoE (6 experts/token + 1 shared) + MLA + DSA sparse attention + native MTP |
 | Quantization | W8A8 (`W8A8_DYNAMIC`, int8 attention + expert; ~280 GB weights, 70 shards, 43 layers); MIT license |
 | Model source (W8A8) | https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp |
+| ModelCar (OCI Image Layout tar) | `http://package-minio.alauda.cn:9199/packages/aml-models-oci/v0.1.0/DeepSeek-V4-Flash-w8a8-mtp.oci.tar` |
 
 :::note
-Unlike the other models in this guide, this W8A8 variant has **no public Docker Hub
-ModelCar** — the ~280 GB weights are pulled from the ModelScope source above and staged
-on a **node-local PVC on each of the two nodes** (rank 0 mounts the node-0 copy, rank 1
-the node-1 copy). The deployment manifest uses `pvc://` sources rather than an
-`oci://` ModelCar; repoint the two claims at wherever you stage the weights.
+The W8A8 ModelCar is distributed as an **OCI Image Layout tar** on the internal package
+store (link above), not a public Docker Hub image. The cluster pulls an OCI *image*, not
+the tar, so **import it into your own registry once** and point `model.uri` at that —
+see the **Deploy** section below. The benchmark itself was run with the weights staged on a
+**node-local PVC per node**; the ModelCar is the same weights repackaged (the manifest
+header documents that PVC alternative).
 :::
 
 ## Validated hardware × stack
@@ -109,8 +111,18 @@ store):
 
 ```bash
 base=https://raw.githubusercontent.com/alauda/aml-docs/master/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8
-# Edit first: set the namespace, repoint the two node-local weight PVC claims
-# (dsv4-n8 / dsv4-n9), and the image tag (match your CANN / host driver). Then:
+
+# 1. Import the ModelCar (OCI Image Layout tar) into your own registry once — the cluster
+#    pulls an OCI image, not the tar. skopeo does the multi-arch (amd64+arm64) push in one go:
+curl -sO http://package-minio.alauda.cn:9199/packages/aml-models-oci/v0.1.0/DeepSeek-V4-Flash-w8a8-mtp.oci.tar
+skopeo copy --all \
+  oci-archive:DeepSeek-V4-Flash-w8a8-mtp.oci.tar:v0.1.0 \
+  docker://<your-registry>/modelcar-deepseek-v4-flash-w8a8-mtp:v0.1.0
+
+# 2. Edit the manifest: set the namespace, set model.uri to the registry ref you just
+#    pushed, and the image tag (match your CANN / host driver). Then apply — the
+#    storageInitializer pulls the ModelCar to /mnt/models in each DP rank.
+#    (Alternative: stage the weights on a node-local PVC per node — see the manifest header.)
 kubectl apply -f $base/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml
 
 # Internal KServe ingress (no auth):

--- a/docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx
+++ b/docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx
@@ -1,0 +1,166 @@
+---
+weight: 40
+i18n:
+  title:
+    en: DeepSeek-V4-Flash (W8A8)
+    zh: DeepSeek-V4-Flash (W8A8)
+---
+
+# DeepSeek-V4-Flash (W8A8)
+
+`deepseek_v4`-architecture model — a 256-expert MoE with MLA + DSA sparse attention
+and a native MTP speculative head, served as **W8A8** (int8 attention + expert,
+~280 GB weights, 70 shards, 43 layers). At ~280 GB the weights do not fit a single
+8 × 32 GB node, so it was validated on **Ascend 910B3 (64 GB/card) across two
+nodes = 16 cards** as a single aggregated **DP2 × TP=8 + EP16** service, with the
+vLLM-Ascend **nightly** engine through Alauda AI's InferNex surface. It adds a **mooncake
+cross-rank KV store** so the two data-parallel ranks share prefix KV, and both benchmark
+scenarios were driven through the **MaaS gateway (API-key) ingress** as a concurrency
+sweep (8 / 16 / 32).
+
+## Model identity
+
+| Field | Value |
+|---|---|
+| Publisher | DeepSeek |
+| Architecture | `deepseek_v4` — 256-expert MoE (6 experts/token + 1 shared) + MLA + DSA sparse attention + native MTP |
+| Quantization | W8A8 (`W8A8_DYNAMIC`, int8 attention + expert; ~280 GB weights, 70 shards, 43 layers); MIT license |
+| Model source (W8A8) | https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp |
+
+:::note
+Unlike the other models in this guide, this W8A8 variant has **no public Docker Hub
+ModelCar** — the ~280 GB weights are pulled from the ModelScope source above and staged
+on a **node-local PVC on each of the two nodes** (rank 0 mounts the node-0 copy, rank 1
+the node-1 copy). The deployment manifest uses `pvc://` sources rather than an
+`oci://` ModelCar; repoint the two claims at wherever you stage the weights.
+:::
+
+## Validated hardware × stack
+
+| Platform | Engine | Version / config | Status |
+|---|---|---|---|
+| Ascend 910B3 64 GB × 16, 2 nodes (1 instance, DP2 × TP=8 + EP16) | vLLM-Ascend | `nightly-main-openeuler` (vLLM 0.23.0) | ✅ closed-loop, 2-scenario **concurrency sweep (8/16/32)**, 480 req/tier, 0 error / 0 mismatch, agg + mooncake KV store, via MaaS gateway |
+
+:::note
+The nightly-main image carries the full `deepseek_v4` stack **and** the DP2 cross-node
+graph + DSA-CP prefix-cache fixes. `enable_dsa_cp` is intentionally **on** — it is a
+prerequisite for a non-zero prefix-cache hit, and this build is stable with it. With the
+full hit gate satisfied (see the config table), **prefix caching works** — ~90.9 %
+single-rank hit at a 21k prefix.
+:::
+
+## Model configuration
+
+| Parameter | Value |
+|---|---|
+| Tensor parallelism (`tensor-parallel-size`) | 8 |
+| Data parallelism (`data-parallel-size`) | 2 (1 rank per node, cross-node) |
+| Replicas (instances) | 1 aggregated service (leader + worker = 16 cards) |
+| Expert parallelism (`enable-expert-parallel`) | on (EP16) |
+| `max-model-len` | 200000 (agent long-context) |
+| `max-num-batched-tokens` | 8192 |
+| `max-num-seqs` | 32 |
+| `gpu-memory-utilization` | 0.92 (64 GB card — ~20.6 GB/card weights leave ample KV room) |
+| `block-size` | 128 |
+| Quantization | `ascend` (W8A8_DYNAMIC) |
+| Speculative decoding (MTP) | `mtp`, 1 token (`enforce_eager` on the draft head) |
+| Decode graph | `FULL_DECODE_ONLY` (`enable_npugraph_ex`) |
+| DSA context parallel (`enable_dsa_cp`) | on (prefix-cache hit prerequisite) |
+| Prefix caching | enabled **and effective** (~90.9 % single-rank hit; requires `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` + `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=16384` + prefix ≥ 16384) |
+| Tool calling / reasoning | `--tool-call-parser deepseek_v4` + `--enable-auto-tool-choice` + `--reasoning-parser deepseek_v4` (thinking off by default) |
+
+## Deployment spec
+
+Served as **`agg-mc-kv`** — a single DP2 × TP=8 aggregation **plus** a mooncake KV store
+shared by the two DP ranks. DP2 random routing scatters each user's growing history
+across the two ranks, so per-rank local multi-turn hit is only ~41 %; the mooncake store
+lets one rank pull prefix KV the other already computed, lifting **merged effective
+prefix reuse to ~84 %**. The router stays `random` and the cache-indexer is **off**: a
+single aggregated endpoint needs no global KV index or KV-cache-aware routing — this
+matches the GLM-5.2 / Qwen3-8B aggregation paradigm (store shares KV; router stays
+random).
+
+| Component | `agg-mc-kv` |
+|---|:--:|
+| hermes-router (EPP) | ✅ started (single leader endpoint, `random` no-op) |
+| Routing strategy | `random` |
+| mooncake KV store (AscendStoreConnector) | ✅ (shared across the two DP ranks) |
+| cache-indexer / KV-cache-aware routing | — (not needed for a single aggregated endpoint) |
+| Cross-rank prefix KV reuse | yes (~84 % merged effective) |
+
+:::note
+The store writes **asynchronously** (~30–60 s to land a 21k prefix). Cross-rank hits
+land for multi-turn agent sessions with turn gaps of roughly a minute or more;
+back-to-back sub-second reuse only hits the same rank's local prefix cache. A separate
+attempt at KV-cache-aware routing (to steer follow-ups back to the rank holding the
+cache) was evaluated and **reverted** — it gave no benefit on this stack at this scale,
+so the production form stays `random` + mooncake store.
+:::
+
+## Deploy
+
+Self-contained InferNex manifest (engine inlined in the `LLMInferenceService` leader +
+worker templates + hermes-router preset, DP2 × TP=8 across two nodes with the mooncake
+store):
+
+| Spec | File |
+|---|---|
+| agg-mc-kv, DP2 × TP=8 | [`deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml`](https://github.com/alauda/aml-docs/tree/master/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml) |
+
+```bash
+base=https://raw.githubusercontent.com/alauda/aml-docs/master/docs/en/inference_guide/assets/deepseek-v4-flash-w8a8
+# Edit first: set the namespace, repoint the two node-local weight PVC claims
+# (dsv4-n8 / dsv4-n9), and the image tag (match your CANN / host driver). Then:
+kubectl apply -f $base/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml
+
+# Internal KServe ingress (no auth):
+curl -s http://<gateway>/<namespace>/deepseek-v4-flash-w8a8-agg-mc-kv/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"deepseek-v4-flash-w8a8","messages":[{"role":"user","content":"hello"}]}'
+
+# Product MaaS gateway (OpenAI-compatible, API-key auth + token rate limiting):
+curl -s http://<maas-gateway>/v1/chat/completions \
+  -H "Authorization: Bearer $MAAS_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"deepseek-v4-flash-w8a8","messages":[{"role":"user","content":"hello"}]}'
+```
+
+## Benchmark results
+
+Closed-loop `aiperf`, **DP2 × TP=8 (16 × 910B3 64 GB)**, agg-mc-kv, driven through the
+product **MaaS gateway**. Two scenarios — ① 8k system-prompt reuse and ② 17.5k
+multi-turn — each swept at **concurrency 8 / 16 / 32**, 480 requests per tier (all tiers
+0 error / 0 mismatch). TTFT / E2E in s, ITL in ms; decode = output-only tok/s (measured),
+TPS = total tokens/s (input + output, computed).
+
+**Scenario ① — fixed-length system-prompt reuse (ISL ~8k / OSL 128)**
+
+| Concurrency | TTFT avg (s) | ITL avg (ms) | E2E avg (s) | Decode (tok/s) | TPS (in+out) |
+|--:|--:|--:|--:|--:|--:|
+| 8  | 3.19 | 305 | 41.9 | 24.2 | 1539 |
+| 16 | 3.42 | 350 | 47.8 | 42.3 | 2689 |
+| 32 | 5.71 | 493 | 68.3 | 59.2 | 3759 |
+
+**Scenario ② — multi-turn dialogue (ISL ~17.5k / OSL 128)**
+
+| Concurrency | TTFT avg (s) | ITL avg (ms) | E2E avg (s) | Decode (tok/s) | TPS (in+out) |
+|--:|--:|--:|--:|--:|--:|
+| 8  | 6.06 | 356 | 51.3 | 19.9 | 2802 |
+| 16 | 7.53 | 459 | 65.8 | 30.9 | 4357 |
+| 32 | 10.17 | 579 | 83.7 | 48.1 | 6781 |
+
+:::note
+**How to read these.** Every tier completed 480/480 with zero errors and zero output
+mismatches. As concurrency rises, **system throughput (decode / TPS) climbs**
+(sub-linear, saturating) while **TTFT / ITL / E2E also climb** — the queueing cost of
+more in-flight requests. This is a **prefill-heavy** workload (ISL 8k / 17.5k, OSL 128),
+so aggregate prefill throughput (~1600 tok/s at the 8k tier) dominates and latency is
+naturally high. The mooncake KV store is what lifts multi-turn prefix reuse from ~41 %
+(per-rank local) to ~84 % (merged effective), worth roughly **TTFT −24…44 % / decode
+throughput +24…67 %** versus a mooncake-free graph build.
+
+These numbers are **not directly comparable** to the other models in this guide: this is
+a concurrency sweep (not the fixed concurrency-4 run the Qwen models use), on **910B3
+64 GB** cards (not 910B4 32 GB), with a **16-card DP2 × TP=8** topology. Treat them as
+the operating envelope of this specific large-MoE deployment, not a cross-model ranking.
+:::

--- a/docs/en/inference_guide/index.mdx
+++ b/docs/en/inference_guide/index.mdx
@@ -150,9 +150,11 @@ The three signed images and their digests:
 | `docker.io/alaudadockerhub/modelcar-deepseek-v4-flash-w4a8-mtp:v0.1.0` | `sha256:ef57a46726bec9c6505504262beaa55ec6c45d595a1726ab90d594f42606c6be` |
 
 :::note
-DeepSeek-V4-Flash (**W8A8**) is not in this table — it has no public ModelCar image. Its
-~280 GB weights are staged from the ModelScope source onto a node-local PVC per node (see
-its [page](./deepseek-v4-flash-w8a8.mdx)), so there is no signed image to verify.
+DeepSeek-V4-Flash (**W8A8**) is not in this Cosign table — its ModelCar is distributed as
+an **OCI Image Layout tar** (not a signed registry image), so there is no Cosign signature
+to verify. Its integrity is content-addressed instead: the tar's `index.json` carries the
+image digest and every blob under `blobs/sha256/` is verified against its own digest on
+import (`skopeo copy` checks this). See its [page](./deepseek-v4-flash-w8a8.mdx).
 :::
 
 `--insecure-ignore-tlog=true` is required because these were signed with

--- a/docs/en/inference_guide/index.mdx
+++ b/docs/en/inference_guide/index.mdx
@@ -13,13 +13,14 @@ in this guide has been deployed end-to-end on a real cluster and benchmarked, so
 get a known-good deployment manifest, the runtime image that serves it, and the
 throughput you can expect.
 
-The models here were validated on **Huawei Ascend 910B4 NPU** with the community
-`vLLM-Ascend` engine, deployed through Alauda AI's **InferNex** surface — a KServe
-`LLMInferenceService` reconciled by the InferNex-Bridge into a load-aware router
-(hermes-router / EPP) in front of the vLLM-Ascend instances. All were run through the
+The models here were validated on **Huawei Ascend NPUs (910B4 and 910B3)** with the
+community `vLLM-Ascend` engine, deployed through Alauda AI's **InferNex** surface — a
+KServe `LLMInferenceService` reconciled by the InferNex-Bridge into a load-aware router
+(hermes-router / EPP) in front of the vLLM-Ascend instances. Most were run through the
 **same InferNex aggregation surface and the same two benchmark scenarios** (the two
-Qwen models share an identical 2 × TP=4 topology and are directly comparable; the
-larger DeepSeek MoE uses 1 × TP=8). For the runtime model (KServe, ModelCar storage,
+Qwen models share an identical 2 × TP=4 topology and are directly comparable;
+DeepSeek-V4-Flash uses larger topologies, up to a 16-card DP2 × TP=8 cross-node
+aggregation). For the runtime model (KServe, ModelCar storage,
 scheduling) see [Model Deployment & Inference](../model_inference/index.mdx).
 
 ## Validated models
@@ -29,12 +30,19 @@ scheduling) see [Model Deployment & Inference](../model_inference/index.mdx).
 | Qwen3-32B | Qwen3 dense | 32B | BF16 | Ascend 910B4 ×8 | vLLM-Ascend v0.18.0 | [Qwen3-32B](./qwen3-32b.mdx) |
 | Qwen3.6-27B (W8A8) | `qwen3_5` hybrid (GDN + MTP) | 27.78B | W8A8 | Ascend 910B4 ×8 | vLLM-Ascend nightly | [Qwen3.6-27B (W8A8)](./qwen3-6-27b-w8a8.mdx) |
 | DeepSeek-V4-Flash (W4A8) | `deepseek_v4` MoE (MLA + DSA + MTP) | 256-expert MoE | W4A8 | Ascend 910B4 ×8 | vLLM-Ascend nightly | [DeepSeek-V4-Flash (W4A8)](./deepseek-v4-flash-w4a8.mdx) |
+| DeepSeek-V4-Flash (W8A8) | `deepseek_v4` MoE (MLA + DSA + MTP) | 256-expert MoE | W8A8 | Ascend 910B3 ×16 | vLLM-Ascend nightly | [DeepSeek-V4-Flash (W8A8)](./deepseek-v4-flash-w8a8.mdx) |
 
-All three were validated on Ascend 910B4 (32 GB/card), driven through KServe
-`LLMInferenceService` with load-aware routing (InferNex-Bridge + hermes-router). The
-two Qwen models run an **8-card aggregation — 2 instances × TP=4**; DeepSeek-V4-Flash
-(~151 GB W4A8) fills all 8 cards as **1 instance × TP=8**, and additionally validated
-the **MaaS gateway (API-key) ingress** next to the internal KServe ingress.
+The two Qwen models and DeepSeek-V4-Flash (W4A8) were validated on Ascend 910B4 (32 GB/card),
+driven through KServe `LLMInferenceService` with load-aware routing (InferNex-Bridge +
+hermes-router). The two Qwen models run an **8-card aggregation — 2 instances × TP=4**;
+DeepSeek-V4-Flash (~151 GB W4A8) fills all 8 cards as **1 instance × TP=8**, and
+additionally validated the **MaaS gateway (API-key) ingress** next to the internal
+KServe ingress.
+
+DeepSeek-V4-Flash (W8A8, ~280 GB) was validated on **Ascend 910B3 (64 GB/card) across
+two nodes = 16 cards** as a single **DP2 × TP=8 cross-node aggregation** with a
+**mooncake cross-rank KV store**, driven through both the internal KServe ingress and
+the product MaaS gateway.
 
 ## Runtime images
 
@@ -42,6 +50,7 @@ the **MaaS gateway (API-key) ingress** next to the internal KServe ingress.
 |---|---|---|---|---|
 | vLLM-Ascend v0.18.0 | Huawei Ascend NPU | `quay.io/ascend/vllm-ascend:v0.18.0-openeuler` | Qwen3-32B | Community vLLM for Ascend, V1 engine. Serves standard Qwen3 dense models directly. Match the tag's CANN version to your host NPU driver. |
 | vLLM-Ascend nightly (release-pinned) | Huawei Ascend NPU | `quay.io/ascend/vllm-ascend:nightly-releases-v0.22.1rc-openeuler` | Qwen3.6-27B (W8A8), DeepSeek-V4-Flash (W4A8) | Carries the `qwen3_5` Gated DeltaNet hybrid + MTP **and** the `deepseek_v4` MoE stack — the stock `v0.18.0` cannot load either. Use this **release-pinned** tag, **not** the moving `nightly-main-openeuler` (it drifted to a broken build whose TP workers crash). |
+| vLLM-Ascend nightly-main (dated snapshot) | Huawei Ascend NPU | `quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709` | DeepSeek-V4-Flash (W8A8) | A **later** `nightly-main` snapshot (vLLM 0.23.0) that carries the DP2 cross-node graph + DSA-CP prefix-cache fixes the W8A8 cross-node deployment needs. Pin a **dated** snapshot like this one, not the moving `nightly-main` tag. |
 
 :::tip
 The Ascend CANN images are arm64. Always match the runtime image's CANN version to
@@ -51,9 +60,11 @@ are listed; other engines (MindIE, SGLang, …) were not benchmarked at this siz
 
 ## Benchmark scenarios
 
-Both models were measured with `aiperf` against the same two scenarios, modelled on
+These models were measured with `aiperf` against the same two scenarios, modelled on
 real serving patterns. Output is pinned to **128 tokens** and load is **closed-loop,
-concurrency 4** (4 in-flight requests, fixed). Each scenario ran 240 requests.
+concurrency 4** (4 in-flight requests, fixed); each scenario ran 240 requests.
+DeepSeek-V4-Flash (W8A8) is the exception — it was swept at **concurrency 8 / 16 / 32**
+(480 requests per tier).
 
 | Scenario | What it models | Dataset | Request shape |
 |---|---|---|---|
@@ -61,14 +72,18 @@ concurrency 4** (4 in-flight requests, fixed). Each scenario ran 240 requests.
 | **② Multi-turn dialogue** | Multiple users in a continuing conversation, several requests per session. | 60 independent users × 4 rounds = 240 requests. | Round 1 sends 16k and the model replies 128 tokens; round 2 adds 1k (~17k total); and so on for 4 rounds (16k / 17k / 18k / 19k), averaging **~17.5k** ISL / OSL 128. |
 
 :::note
-Both scenarios run on a **single-node 8-card** deployment (Qwen models: 2 instances ×
-TP=4; DeepSeek-V4-Flash: 1 instance × TP=8). Latency (TTFT / ITL / E2E) is the
-per-instance operating point under steady 2-in-flight load; total throughput (TPS) is
-the aggregate across the instances and scales with the instance count. **TPS is the
-total-token (input + output) caliber**; the decode-only output rate is reported
-separately and is much smaller under these long-input workloads. DeepSeek-V4-Flash
-additionally ran each scenario through the **MaaS gateway (API-key) ingress** as well
-as the internal KServe ingress — see its page.
+The two Qwen models and DeepSeek-V4-Flash (W4A8) run these scenarios on a **single-node
+8-card** deployment (Qwen models: 2 instances × TP=4; DeepSeek-V4-Flash W4A8: 1 instance
+× TP=8). Latency (TTFT / ITL / E2E) is the per-instance operating point under steady
+2-in-flight load; total throughput (TPS) is the aggregate across the instances and
+scales with the instance count. **TPS is the total-token (input + output) caliber**; the
+decode-only output rate is reported separately and is much smaller under these
+long-input workloads.
+
+DeepSeek-V4-Flash (W8A8) instead runs a **16-card DP2 × TP=8 cross-node** deployment and
+is swept at **concurrency 8 / 16 / 32** (480 req/tier), so its numbers are an operating
+envelope reported on its own page. It was driven through both the internal KServe
+ingress and the product **MaaS gateway (API-key) ingress**.
 :::
 
 ## Deploy a validated model
@@ -133,6 +148,12 @@ The three signed images and their digests:
 | `docker.io/alaudadockerhub/modelcar-qwen3-32b:v0.1.0` | `sha256:eccffdb567038196638eb7e1c6bb9572d8bcc7829d11fcdfa17f2c43fbca0c6e` |
 | `docker.io/alaudadockerhub/modelcar-qwen3-6-27b-w8a8:v0.1.0` | `sha256:5eb8841a29a4f3d659f8cef25c7f8b16208b32265db23354dae79c4c04e8ef79` |
 | `docker.io/alaudadockerhub/modelcar-deepseek-v4-flash-w4a8-mtp:v0.1.0` | `sha256:ef57a46726bec9c6505504262beaa55ec6c45d595a1726ab90d594f42606c6be` |
+
+:::note
+DeepSeek-V4-Flash (**W8A8**) is not in this table — it has no public ModelCar image. Its
+~280 GB weights are staged from the ModelScope source onto a node-local PVC per node (see
+its [page](./deepseek-v4-flash-w8a8.mdx)), so there is no signed image to verify.
+:::
 
 `--insecure-ignore-tlog=true` is required because these were signed with
 `--tlog-upload=false` (no public transparency-log entry); verification relies on the


### PR DESCRIPTION
## What

Adds a validated-model inference guide page for **DeepSeek-V4-Flash (W8A8)**, in the
same format as the existing inference guide.

- `docs/en/inference_guide/deepseek-v4-flash-w8a8.mdx` — new model page
- `docs/en/inference_guide/assets/deepseek-v4-flash-w8a8/deepseek-v4-flash-w8a8-agg-mc-kv-llmisvc.yaml` — the validated InferNex manifest
- `docs/en/inference_guide/index.mdx` — new table row + an independent W8A8 description, runtime image, benchmark-scenario and Cosign notes

## The W8A8 validation

- **Hardware**: Ascend 910B3 64 GB × 16 (2 nodes)
- **Topology**: DP2 × TP=8 + EP16 cross-node aggregation — a single service (leader + worker), not two replicas
- **Engine**: `quay.io/ascend/vllm-ascend:nightly-main-openeuler-0709` (vLLM 0.23.0)
- **mooncake cross-rank KV store**: lifts multi-turn prefix reuse from ~41 % (per-rank local) to ~84 % (merged effective)
- FULL_DECODE_ONLY graph, DSA-CP on, prefix cache effective (~90.9 % single-rank hit), `max-model-len` 200000, tool calling enabled
- **Benchmark** (production agg-mc-kv, scenario ② multi-turn): concurrency sweep 8 / 16 / 32, 480 req/tier, 0 error; conc32 = **TTFT 1.9 s / decode 230.9 tok/s / in+out TPS 32559**, with a base→+graph→+mc-kv evolution table showing where the ~4.8× gain comes from

## Model distribution (ModelCar)

- Distributed as an **OCI Image Layout tar** on the internal package store:
  `http://package-minio.alauda.cn:9199/packages/aml-models-oci/v0.1.0/DeepSeek-V4-Flash-w8a8-mtp.oci.tar`
- The cluster pulls an OCI **image**, not the tar, so the Deploy steps import it once
  (`skopeo copy --all oci-archive:…:v0.1.0 docker://<your-registry>/…`) and set
  `model.uri: oci://<your-registry>/modelcar-deepseek-v4-flash-w8a8-mtp:v0.1.0`.
- The manifest now **defaults to the ModelCar (`oci://` + storageInitializer)**; the
  node-local PVC path (what the benchmark actually ran on) is kept as a documented
  alternative in the manifest header. The DP2 cross-node storageInitializer pull path was
  not separately re-run for this model — stated honestly in the header.
- **No Cosign signature** — integrity is content-addressed via the OCI tar (`index.json`
  digest + per-blob sha256 verified on `skopeo copy`); the Cosign section notes this.

## Notes

- The benchmark numbers are a concurrency-sweep envelope on 910B3, **not directly
  comparable** to the fixed concurrency-4 runs of the other models — the page calls this out.

Source of the validated config and benchmark data: the `model-auto` DeepSeek-V4-Flash
validation (Guian 2 × 8 × 910B3, 2026-07-09).

`doom lint` passes with 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
