### PR TITLE
docs(training-guides): add checkpointing and resuming TrainJobs guide

### DIFF
--- a/docs/en/training_guides/assets/checkpointing/checkpoint-pvc.yaml
+++ b/docs/en/training_guides/assets/checkpointing/checkpoint-pvc.yaml
@@ -1,0 +1,28 @@
+# Durable checkpoint storage for a TrainJob.
+#
+# Access mode:
+#   numNodes: 1   -> ReadWriteOnce is enough. A network-attached RWO volume
+#                    (Ceph RBD, EBS, ...) detaches from the old node and
+#                    re-attaches wherever the restarted pod lands, so a resume
+#                    on a different node works. RWO means "one node at a time",
+#                    not "one node forever".
+#   numNodes: > 1 -> ReadWriteMany is required: every trainer pod mounts this
+#                    PVC at the same time. Use CephFS / NFS / any RWX class.
+#
+# Do NOT use a hostPath or a local-storage class for checkpoints: a pod that
+# restarts onto another node will silently start from scratch.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: train-ckpt
+  namespace: <your-namespace>
+spec:
+  # Edit to your cluster's class. `kubectl get storageclass` to list them.
+  # For numNodes > 1 this must be an RWX-capable class.
+  storageClassName: ceph-rbd
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      # Size for: (checkpoint size x save_total_limit) + headroom.
+      # A full-weight 7B checkpoint with optimizer state is ~80Gi *each*.
+      storage: 20Gi

--- a/docs/en/training_guides/assets/checkpointing/checkpoint-trainingruntime.yaml
+++ b/docs/en/training_guides/assets/checkpointing/checkpoint-trainingruntime.yaml
@@ -1,0 +1,161 @@
+# A checkpoint-aware TrainingRuntime for Kubeflow Trainer v2.
+#
+# The three pieces that make a TrainJob resumable:
+#   1. `ckpt` volume  -> checkpoints outlive the pod (see checkpoint-pvc.yaml).
+#   2. save_strategy/save_steps -> checkpoints are written often enough that a
+#      restart loses a bounded amount of work.
+#   3. resume_from_checkpoint -> every start after the first picks up the
+#      newest checkpoint instead of starting over.
+#
+# Plus two restart knobs so a failure is retried at all:
+#   - failurePolicy.maxRestarts -> JobSet recreates the trainer pods.
+#   - terminationGracePeriodSeconds -> the trainer can flush a final
+#     checkpoint on SIGTERM before SIGKILL.
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: checkpoint-runtime
+  namespace: <your-namespace>
+  labels:
+    trainer.kubeflow.org/framework: torch
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: auto
+  template:
+    spec:
+      failurePolicy:
+        # Recreate the trainer pods up to 3 times before declaring the
+        # TrainJob failed. Each recreated pod resumes from the last checkpoint.
+        maxRestarts: 3
+      replicatedJobs:
+        - name: node
+          template:
+            metadata:
+              labels:
+                # REQUIRED. Without this label the controller does not treat
+                # this replicatedJob as the trainer step, and every
+                # `spec.trainer.*` field on the TrainJob (env, resourcesPerNode,
+                # image, command, numNodes) is silently ignored.
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              # 0 = don't let the Job retry the pod itself; let the JobSet
+              # failurePolicy above own restarts, so restarts are counted and
+              # capped in one place.
+              backoffLimit: 0
+              template:
+                spec:
+                  # Give the trainer room to flush a final checkpoint on SIGTERM.
+                  terminationGracePeriodSeconds: 60
+                  imagePullSecrets:
+                    - name: harbor-mlops-regcred
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 65534
+                    runAsGroup: 65534
+                    fsGroup: 65534
+                  volumes:
+                    - name: ckpt
+                      persistentVolumeClaim:
+                        claimName: train-ckpt
+                    - name: workspace
+                      emptyDir: {}
+                    - name: dshm
+                      emptyDir:
+                        medium: Memory
+                        sizeLimit: 2Gi
+                  containers:
+                    - name: node
+                      image: docker.io/alaudadockerhub/torch2.6-cu126-amd64:v0.1.0
+                      env:
+                        - { name: PYTHONUNBUFFERED, value: "1" }
+                        - { name: HF_HOME, value: /workspace/hf_cache }
+                        # Defaults; override per-run via TrainJob spec.trainer.env.
+                        - { name: CKPT_DIR, value: /mnt/ckpt/run }
+                        - { name: SAVE_STEPS, value: "50" }
+                        - { name: NUM_TRAIN_EPOCHS, value: "3" }
+                      volumeMounts:
+                        - { name: ckpt, mountPath: /mnt/ckpt }
+                        - { name: workspace, mountPath: /workspace }
+                        - { name: dshm, mountPath: /dev/shm }
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop: ["ALL"]
+                        seccompProfile:
+                          type: RuntimeDefault
+                      resources:
+                        requests:
+                          cpu: "1"
+                          memory: 4Gi
+                        limits:
+                          cpu: "4"
+                          memory: 16Gi
+                          nvidia.com/gpu: 1
+                      command: [bash, -ec]
+                      args:
+                        - |
+                          python - <<'PY'
+                          import glob, os, signal
+                          from transformers import Trainer, TrainerCallback, TrainingArguments
+
+                          ckpt_dir = os.environ["CKPT_DIR"]
+                          os.makedirs(ckpt_dir, exist_ok=True)
+
+                          # 1. Resume: pick the newest checkpoint-N on the PVC.
+                          #    Sort numerically -- a lexical sort puts checkpoint-9
+                          #    after checkpoint-100 and silently rewinds the run.
+                          ckpts = sorted(
+                              glob.glob(f"{ckpt_dir}/checkpoint-*"),
+                              key=lambda p: int(p.rsplit("-", 1)[1]),
+                          )
+                          resume = ckpts[-1] if ckpts else None
+                          print(f"[checkpoint] resuming from {resume}" if resume
+                                else "[checkpoint] no prior checkpoint, starting fresh",
+                                flush=True)
+
+                          # 2. On SIGTERM (preemption, eviction, suspend), save at the
+                          #    next step boundary and stop cleanly. A callback is the
+                          #    supported hook -- do not call trainer.save_model() from
+                          #    the signal handler itself, it is not re-entrant.
+                          class FlushOnSigterm(TrainerCallback):
+                              stopping = False
+
+                              def on_step_end(self, args, state, control, **kwargs):
+                                  if FlushOnSigterm.stopping:
+                                      control.should_save = True
+                                      control.should_training_stop = True
+                                  return control
+
+                          def _on_sigterm(*_):
+                              print("[checkpoint] SIGTERM: flushing at next step", flush=True)
+                              FlushOnSigterm.stopping = True
+
+                          signal.signal(signal.SIGTERM, _on_sigterm)
+
+                          # 3. Save often enough that a restart is cheap.
+                          args = TrainingArguments(
+                              output_dir=ckpt_dir,
+                              save_strategy="steps",
+                              save_steps=int(os.environ["SAVE_STEPS"]),
+                              save_total_limit=2,      # bound PVC growth
+                              num_train_epochs=float(os.environ["NUM_TRAIN_EPOCHS"]),
+                              report_to=[],
+                          )
+
+                          # --- replace with your model / dataset / collator ---
+                          model, train_dataset = ..., ...
+
+                          trainer = Trainer(
+                              model=model,
+                              args=args,
+                              train_dataset=train_dataset,
+                              callbacks=[FlushOnSigterm()],
+                          )
+
+                          # Passing None here is what makes the *first* run start clean.
+                          trainer.train(resume_from_checkpoint=resume)
+                          trainer.save_model(f"{ckpt_dir}/final")
+                          print("[checkpoint] done", flush=True)
+                          PY

--- a/docs/en/training_guides/assets/checkpointing/trainjob-resume.yaml
+++ b/docs/en/training_guides/assets/checkpointing/trainjob-resume.yaml
@@ -1,0 +1,46 @@
+# A TrainJob that checkpoints to a PVC and resumes from it.
+#
+# Submit this once. If the trainer crashes, is preempted, or you suspend and
+# resume it, the *same* manifest is what comes back up -- the resume decision
+# is made by the trainer script reading the PVC, not by anything here.
+#
+# To restart the run from scratch instead of resuming, either point CKPT_DIR at
+# a fresh subdirectory or delete the old checkpoint-* dirs from the PVC.
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  name: sft-resumable
+  namespace: <your-namespace>
+spec:
+  runtimeRef:
+    apiGroup: trainer.kubeflow.org
+    kind: TrainingRuntime
+    name: checkpoint-runtime
+  suspend: false
+  trainer:
+    numNodes: 1
+    # These override the same keys in the TrainingRuntime -- but ONLY if the
+    # runtime's trainer replicatedJob carries the label
+    # `trainer.kubeflow.org/trainjob-ancestor-step: trainer`. Without it these
+    # are dropped without any error.
+    env:
+      - { name: CKPT_DIR, value: /mnt/ckpt/sft-run-1 }
+      - { name: SAVE_STEPS, value: "50" }
+    resourcesPerNode:
+      limits:
+        nvidia.com/gpu: 1
+  # Attach the checkpoint PVC per-job, without editing the shared runtime.
+  # Note: `env` is NOT allowed here for the trainer/initializer containers --
+  # the validating webhook rejects it. Use spec.trainer.env (above) instead.
+  podTemplateOverrides:
+    - targetJobs:
+        - name: node
+      spec:
+        volumes:
+          - name: ckpt
+            persistentVolumeClaim:
+              claimName: train-ckpt
+        containers:
+          - name: node
+            volumeMounts:
+              - { name: ckpt, mountPath: /mnt/ckpt }

--- a/docs/en/training_guides/checkpointing-and-resuming.mdx
+++ b/docs/en/training_guides/checkpointing-and-resuming.mdx
@@ -1,0 +1,280 @@
+---
+weight: 33
+---
+
+# Checkpointing and Resuming TrainJobs
+
+A fine-tune that runs for six hours will eventually meet a node reboot, an evicted pod, a preemption, or an OOM at hour five. Without checkpoints, every one of those events costs you the whole run.
+
+Kubeflow Trainer v2 has **no checkpoint API of its own**. Nothing in the `TrainJob` or `TrainingRuntime` spec writes, finds, or restores a checkpoint. The split is:
+
+| Trainer v2 / JobSet gives you | Your training script must do |
+|---|---|
+| Storage that outlives the pod (a PVC you mount) | Write checkpoints into it periodically |
+| Restarting the pod after a failure (`failurePolicy.maxRestarts`) | Detect the newest checkpoint on start and resume from it |
+| Pausing and resuming on demand (`spec.suspend`) | Exit cleanly on SIGTERM, flushing a final checkpoint |
+
+Get either column wrong and the failure mode is the same and silent: the job restarts, finds nothing, and cheerfully trains from step 0 again.
+
+This guide covers the mechanics. For the specific case of *deliberately* preempting training to give an `InferenceService` its GPU back, see [Preemptible TrainJobs with Kueue](./preemptible-trainjobs-with-kueue.mdx), which builds on everything here.
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| Kubeflow Trainer v2 | `trainer.kubeflow.org/v1alpha1`; see [Fine-Tuning with Kubeflow Trainer v2](./fine-tune-with-trainer-v2) |
+| A PVC and a storage class | `kubectl get storageclass`. See [Pick storage that outlives the pod](#pick-storage-that-outlives-the-pod) for access modes |
+| A training runtime image | Any image from the [runtime catalog](./training-runtimes) |
+| `kubectl` access | Permission to manage `trainjobs`, `trainingruntimes`, and `persistentvolumeclaims` in your namespace |
+
+## What a checkpoint has to contain
+
+"Resume" is not "reload the weights". A checkpoint that only holds model weights restarts your optimizer from zero — momentum buffers, the learning-rate schedule position, and the step counter are all lost, and the loss curve visibly kinks where it resumed.
+
+A resumable checkpoint holds:
+
+- **Model weights**
+- **Optimizer state** — Adam's moment estimates. Typically ~2x the model size in fp32, and usually the largest part of the checkpoint.
+- **LR scheduler state** — so the schedule continues rather than re-warming.
+- **Step / epoch counter** — where to pick up.
+- **RNG state and data-loader position** — so the resumed run doesn't re-see the same samples in the same order.
+
+HuggingFace Trainer's `checkpoint-N/` directories already contain all of this. If you are hand-rolling a loop, saving only `model.state_dict()` is the most common way to get a "resume" that quietly damages the run.
+
+## Pick storage that outlives the pod \{#pick-storage-that-outlives-the-pod}
+
+The checkpoint directory must be on a PVC. An `emptyDir` dies with the pod, and a `hostPath` or local-storage class strands the checkpoint on a node the restarted pod may never land on again.
+
+The access mode depends only on how many trainer pods write at once:
+
+| `numNodes` | Access mode | Why |
+|---|---|---|
+| `1` | `ReadWriteOnce` is enough | One pod mounts it at a time |
+| `> 1` | `ReadWriteMany` is required | Every trainer pod mounts the same PVC simultaneously |
+
+:::note
+`ReadWriteOnce` means "one **node** at a time", not "one node forever". A network-attached RWO volume (Ceph RBD, EBS, and similar) detaches from the old node and re-attaches wherever the restarted pod is scheduled, so a single-node run resumes correctly even when it comes back on a different node. Only *concurrent* multi-pod access needs RWX.
+
+This does not hold for `local-storage` / `topolvm` / `hostPath`, which are physically pinned to one node.
+:::
+
+Apply the PVC ([`checkpoint-pvc.yaml`](https://github.com/alauda/aml-docs/tree/master/docs/en/training_guides/assets/checkpointing/checkpoint-pvc.yaml)):
+
+```bash
+base=https://raw.githubusercontent.com/alauda/aml-docs/master/docs/en/training_guides/assets/checkpointing
+NS=my-namespace   # edit to your namespace
+
+curl -fsSL $base/checkpoint-pvc.yaml | sed "s/<your-namespace>/$NS/" | kubectl apply -f -
+```
+
+Size it for `checkpoint size x save_total_limit`, plus headroom. Full-weight checkpoints are bigger than people expect — a 7B model with optimizer state is roughly 80 GiB *per checkpoint*. LoRA/QLoRA adapters are a few MB, so the same PVC can keep far more of them.
+
+## Make the runtime checkpoint-aware
+
+[`checkpoint-trainingruntime.yaml`](https://github.com/alauda/aml-docs/tree/master/docs/en/training_guides/assets/checkpointing/checkpoint-trainingruntime.yaml) is a runnable `TrainingRuntime` with the whole pattern wired up. The load-bearing parts:
+
+```yaml
+spec:
+  template:
+    spec:
+      failurePolicy:
+        maxRestarts: 3                        # recreate trainer pods on failure
+      replicatedJobs:
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer   # see warning below
+            spec:
+              backoffLimit: 0                 # let failurePolicy own restarts
+              template:
+                spec:
+                  terminationGracePeriodSeconds: 60   # room to flush on SIGTERM
+                  volumes:
+                    - name: ckpt
+                      persistentVolumeClaim: { claimName: train-ckpt }
+                  containers:
+                    - name: node
+                      env:
+                        - { name: CKPT_DIR, value: /mnt/ckpt/run }
+                      volumeMounts:
+                        - { mountPath: /mnt/ckpt, name: ckpt }
+```
+
+And the two lines in the script that actually do the resuming:
+
+```python
+# Sort numerically: a lexical sort puts checkpoint-9 after checkpoint-100
+# and silently rewinds your run by 91 steps.
+ckpts = sorted(glob.glob(f"{ckpt_dir}/checkpoint-*"),
+               key=lambda p: int(p.rsplit("-", 1)[1]))
+resume = ckpts[-1] if ckpts else None    # None on the first run = start clean
+
+trainer.train(resume_from_checkpoint=resume)
+```
+
+That auto-detect is what makes one manifest work for both the first submission and every restart after it. Hardcoding `resume_from_checkpoint=True` fails the first run (no checkpoint exists yet); hardcoding a path pins you to one checkpoint forever.
+
+:::warning
+The `trainer.kubeflow.org/trainjob-ancestor-step: trainer` label on the trainer `replicatedJob` is **required**. Without it the controller does not recognise that replicatedJob as the trainer step, and every `spec.trainer.*` field on your TrainJob — `env`, `resourcesPerNode`, `image`, `command`, `numNodes` — is dropped **silently**: no error, no event, no warning. The TrainJob runs with the runtime's defaults instead, so a job you thought you gave a GPU and a `CKPT_DIR` runs without either.
+
+Verify the overrides landed rather than trusting them:
+
+```bash
+kubectl -n "$NS" get pod <trainer-pod> \
+  -o jsonpath='{.spec.containers[0].env}{"\n"}{.spec.containers[0].resources}{"\n"}'
+```
+:::
+
+Apply the runtime:
+
+```bash
+curl -fsSL $base/checkpoint-trainingruntime.yaml | sed "s/<your-namespace>/$NS/" | kubectl apply -f -
+```
+
+## Submit a resumable TrainJob
+
+[`trainjob-resume.yaml`](https://github.com/alauda/aml-docs/tree/master/docs/en/training_guides/assets/checkpointing/trainjob-resume.yaml) mounts the checkpoint PVC through `podTemplateOverrides`, so one shared runtime can serve many runs that each checkpoint somewhere different:
+
+```yaml
+spec:
+  trainer:
+    env:
+      - { name: CKPT_DIR, value: /mnt/ckpt/sft-run-1 }   # per-run directory
+  podTemplateOverrides:
+    - targetJobs:
+        - name: node
+      spec:
+        volumes:
+          - name: ckpt
+            persistentVolumeClaim: { claimName: train-ckpt }
+        containers:
+          - name: node
+            volumeMounts:
+              - { name: ckpt, mountPath: /mnt/ckpt }
+```
+
+```bash
+curl -fsSL $base/trainjob-resume.yaml | sed "s/<your-namespace>/$NS/" | kubectl create -f -
+```
+
+:::note
+`podTemplateOverrides` can add **volumes, volumeMounts, nodeSelector, tolerations, and affinity**, but it may **not** set `env` on the trainer or initializer containers — the validating webhook rejects the TrainJob outright:
+
+```text
+admission webhook "validator.trainjob.trainer.kubeflow.org" denied the request:
+spec.podTemplateOverrides: must not have envs for the dataset-initializer,
+model-initializer, node containers
+```
+
+Environment variables go in `spec.trainer.env` instead.
+:::
+
+## How each interruption resumes
+
+### A crash or a node failure
+
+Two independent layers restart a failed trainer, and a checkpoint-aware script resumes correctly under both:
+
+```text
+  trainer exits non-zero
+        │
+        ├─ restartPolicy: OnFailure ──► kubelet restarts the container
+        │                                in place, same pod, same node
+        │
+        └─ backoffLimit: 0 ──► Job fails ──► JobSet failurePolicy.maxRestarts
+                                              recreates the pod (possibly on
+                                              another node), PVC re-attaches
+```
+
+Either way the new process runs the same auto-detect and picks up the newest `checkpoint-N`. Watch `restarts` climb on the JobSet:
+
+```bash
+kubectl -n "$NS" get jobset <trainjob-name> -o jsonpath='{.status.restarts}{"\n"}'
+```
+
+Once `maxRestarts` is exhausted the TrainJob goes `Failed` — so set it high enough to absorb transient node churn, but not so high that a genuinely broken script loops forever.
+
+### A preemption
+
+Kueue evicts the Workload and Trainer v2 recreates the JobSet once quota frees up; the trainer resumes from the PVC. The cohort/quota setup is a topic of its own — see [Preemptible TrainJobs with Kueue](./preemptible-trainjobs-with-kueue.mdx).
+
+### A deliberate pause
+
+`spec.suspend` stops a run without losing it — useful to hand a GPU to something urgent for an hour:
+
+```bash
+# Pause: pods are terminated, the TrainJob object stays.
+kubectl -n "$NS" patch trainjob sft-resumable --type=merge -p '{"spec":{"suspend":true}}'
+
+# Resume: a new pod starts and picks up the newest checkpoint.
+kubectl -n "$NS" patch trainjob sft-resumable --type=merge -p '{"spec":{"suspend":false}}'
+```
+
+The resumed pod is a **new** pod with a new name, and may land on a different node. Its first log line should be your `[checkpoint] resuming from ...`.
+
+:::note
+`activeDeadlineSeconds` restarts its countdown when a suspended TrainJob resumes — the job gets the full deadline again after each pause, rather than being measured from creation.
+:::
+
+## Per-framework knobs
+
+Every HuggingFace-Trainer-based stack exposes the same three knobs, so the pattern above transfers unchanged:
+
+| Stack | Save cadence | Resume | Notes |
+|---|---|---|---|
+| HuggingFace `Trainer` | `save_strategy="steps"`, `save_steps=N`, `save_total_limit=2` | `trainer.train(resume_from_checkpoint=path)` | `checkpoint-N/` holds model + optimizer + scheduler + RNG |
+| LlamaFactory | `save_steps` in the YAML config | automatic — it calls `get_last_checkpoint(output_dir)` for you | Wraps HF Trainer. `overwrite_output_dir: true` **skips** that auto-detect, so the run silently starts fresh — leave it off for resumable runs |
+| `training_hub` | `checkpoint_at_epoch: true` | `accelerate_full_state_at_epoch: true` | Only the full-state option is resumable; see [Fine-tuning with Training Hub](./training-hub-fine-tuning) |
+| MindSpeed / Megatron (NPU) | `--save-interval` | automatic from `latest_checkpointed_iteration.txt` | Checkpoint layout is tied to TP/PP degree — see [Ascend NPU guide](./fine-tune-and-pretrain-llms-on-ascend-npu) |
+| Hand-rolled PyTorch | your own `torch.save` | your own `torch.load` | Save optimizer + scheduler + step, not just weights |
+
+Pick `save_steps` from the interruption you can tolerate: the work at risk is at most `save_steps x seconds_per_step`. At 5 s/step, `save_steps: 100` risks ~8 minutes. Saving too often is its own tax — a full-weight checkpoint can take tens of seconds of stalled GPU, so on a stable cluster err large and on a preemptible queue err small. Always pair it with `save_total_limit` so the PVC does not grow without bound.
+
+## Multi-node runs
+
+With `numNodes: > 1` the PVC must be RWX, and two things change:
+
+- **Only rank 0 should write** the checkpoint for standard data-parallel training, or every rank races to write the same path. HF Trainer already handles this; a hand-rolled loop must guard with `if rank == 0`.
+- **All ranks must resume from the same checkpoint.** Ranks that disagree diverge silently rather than crashing.
+
+For sharded strategies (FSDP, DeepSpeed ZeRO), each rank owns a slice of the weights and optimizer state, and gathering it all onto rank 0 is often impossible for large models. That is what [`torch.distributed.checkpoint`](https://docs.pytorch.org/docs/stable/distributed.checkpoint.html) is for: every rank writes its own shard in parallel, and the result can be re-loaded at a **different world size** — so a run checkpointed on 8 GPUs can resume on 4. A checkpoint saved as one gathered file cannot be resharded this way.
+
+## Verify it actually resumes
+
+Do not wait for a real outage to find out. Run this drill once per new runtime:
+
+```bash
+# 1. Submit, and wait for a first checkpoint to appear on the PVC.
+kubectl -n "$NS" exec <trainer-pod> -- ls /mnt/ckpt/sft-run-1
+
+# 2. Force an interruption.
+kubectl -n "$NS" patch trainjob sft-resumable --type=merge -p '{"spec":{"suspend":true}}'
+kubectl -n "$NS" patch trainjob sft-resumable --type=merge -p '{"spec":{"suspend":false}}'
+
+# 3. The new pod's first lines must say it resumed -- not that it started fresh.
+kubectl -n "$NS" logs <new-trainer-pod> | head -3
+```
+
+```text
+[checkpoint] resuming from /mnt/ckpt/sft-run-1/checkpoint-150
+```
+
+If step 3 instead prints `no prior checkpoint, starting fresh`, the resume is broken — and it would have been broken during a real preemption too.
+
+:::note
+Grepping the trainer's logs for HF Trainer's own "Saving model checkpoint to" line is unreliable: the tqdm progress bar overwrites it. Check for `checkpoint-*` directories on the PVC instead, which is what the log line above does.
+:::
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Restarted job trains from step 0 | Checkpoint dir is on an `emptyDir`, or `CKPT_DIR` differs between runs, or the auto-detect glob found nothing |
+| Resumes from a much older checkpoint | Lexical sort of `checkpoint-*` (`checkpoint-9` sorts after `checkpoint-100`) — sort numerically |
+| `spec.trainer.env` / `resourcesPerNode` ignored, no error | Missing `trainer.kubeflow.org/trainjob-ancestor-step: trainer` label on the runtime's trainer replicatedJob |
+| TrainJob rejected: `must not have envs for the ... node containers` | `env` set under `podTemplateOverrides`; move it to `spec.trainer.env` |
+| Loss curve kinks upward on resume | Checkpoint has weights but no optimizer/scheduler state |
+| Pod `Pending` on resume, volume won't attach | RWO PVC still attached to the old node, or `numNodes > 1` against a non-RWX class |
+| PVC full mid-run | `save_total_limit` unset |
+| Final checkpoint missing after preemption | `terminationGracePeriodSeconds` too short to flush |

--- a/docs/en/training_guides/index.mdx
+++ b/docs/en/training_guides/index.mdx
@@ -11,6 +11,7 @@ End-to-end recipes for fine-tuning and pretraining LLMs on Alauda AI.
 | When you want… | Use | Guide |
 |---|---|---|
 | Reusable templates, repeatable runs, optional Kueue quotas | Kubeflow Trainer v2 + LlamaFactory | [Fine-Tuning with Kubeflow Trainer v2](./fine-tune-with-trainer-v2.mdx) |
+| Survive crashes, preemption, or a pause without losing hours of training | Checkpoint PVC + `resume_from_checkpoint` + `maxRestarts` | [Checkpointing and Resuming TrainJobs](./checkpointing-and-resuming.mdx) |
 | Mix training with online inference, yield GPU back on demand | Kueue cohort + preemption + checkpoint resume | [Preemptible TrainJobs with Kueue](./preemptible-trainjobs-with-kueue.mdx) |
 | Run a fine-tune on a *slice* of a GPU instead of a whole card | Dynamic Resource Allocation (DRA) MIG slice + Trainer v2 | [GPU Slicing with Dynamic Resource Allocation (DRA)](./gpu-slicing-with-dra.mdx) |
 | A curated set of `TrainingRuntime` images (CUDA / CANN) | Trainer v2 runtime catalog | [Training Runtime Images](./training-runtimes.mdx) |


### PR DESCRIPTION
## What

Adds a new **Checkpointing and Resuming TrainJobs** guide to the training guides, plus three runnable assets and a routing row in the index.

Kubeflow Trainer v2 has **no checkpoint API of its own** — the platform provides durable storage, pod restarts (`failurePolicy.maxRestarts`), and pause/resume (`spec.suspend`), while the training script must write checkpoints and auto-detect the newest one on start. Get either half wrong and the failure is silent: the job restarts and trains from step 0. This guide documents that split and the non-obvious API behaviour around it.

## Contents

- **`checkpointing-and-resuming.mdx`** (weight 33 — between the main Trainer v2 guide and the preemption guide that builds on it):
  - What a resumable checkpoint must contain (weights **+ optimizer + scheduler + step + RNG**, not just weights)
  - Storage access modes — RWO vs RWX and when each is actually required
  - A checkpoint-aware `TrainingRuntime`, with the resume auto-detect explained
  - How each interruption resumes: crash / node failure, preemption, deliberate `suspend`
  - Per-framework knobs (HF Trainer, LlamaFactory, training_hub, MindSpeed, hand-rolled)
  - Multi-node runs and `torch.distributed.checkpoint` (DCP) — the repo's first DCP mention
  - A verify drill and a troubleshooting table
- **Assets** under `assets/checkpointing/`: `checkpoint-pvc.yaml`, `checkpoint-trainingruntime.yaml`, `trainjob-resume.yaml`
- **`index.mdx`**: one new routing row

It deliberately does **not** restate the HuggingFace `save_steps`/`resume_from_checkpoint` recipe that `preemptible-trainjobs-with-kueue.mdx` already owns; instead it's the general mechanics doc that guide now links to (and vice-versa).

## Verification

Behaviour was validated live against **Kubeflow Trainer v2.1.0** with a CPU-only TrainJob driven through crash, `suspend`, and cross-node resume. Findings folded into the doc:

- The `trainer.kubeflow.org/trainjob-ancestor-step: trainer` label on the trainer replicatedJob is **required** — without it, every `spec.trainer.*` override (`env`, `resourcesPerNode`, `image`, `command`, `numNodes`) is dropped **silently**, no error or event.
- `podTemplateOverrides` can mount volumes but the validating webhook **rejects `env`** on trainer/initializer containers — env must go in `spec.trainer.env`.
- A **ReadWriteOnce** PVC (Ceph RBD) follows the pod across nodes, so single-node resume does not require RWX; RWX is only needed for `numNodes > 1`.

All three assets pass `kubectl apply --dry-run=server`, and `doom lint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
