### PR TITLE
docs: update MLflow v3.13.0 and Workbench v0.2.0

### DIFF
--- a/docs/en/installation/workbench.mdx
+++ b/docs/en/installation/workbench.mdx
@@ -4,17 +4,84 @@ weight: 15
 
 # Install Workbench
 
+Workbench v0.2.0 is delivered as an **OLM Helm operator**. Install the operator from **OperatorHub**, then create a `Workbench` custom resource that deploys and manages `workspace-controller` and the built-in JupyterLab and code-server `WorkspaceKind` resources.
+
 ## Prerequisites
 
-Before installing Workbench, make sure ASM (Istio) is deployed in the business cluster where Workbench will run. Workbench creates an Istio `EnvoyFilter` for Elyra and Kubeflow Pipelines run URL redirection, so the Istio CRDs must exist before the Workbench cluster plugin is installed.
+- Alauda AI is installed on the target cluster.
+- Operator Lifecycle Manager (OLM) is available through the platform.
+- cert-manager is installed for the workspace-controller webhook certificate.
+- The separate `aml-skipper` component is installed for Workbench routing.
+- **Optional:** ASM (Istio) is required only for the Elyra Kubeflow Pipelines run-URL redirect. Workbench v0.2.0 disables Istio integration by default and can install without Istio CRDs.
 
-## Installing Alauda AI Workbench Cluster Plugin
+## Upload the operator
+
+Download the **Alauda AI Workbench Operator v0.2.0** bundle from the <Term name="company" /> Customer Portal / Marketplace. If it is not already available in OperatorHub, publish the downloaded bundle to the platform repository:
+
+```bash
+violet push \
+  --platform-address=<platform-access-address> \
+  --platform-username=<platform-admin> \
+  --platform-password=<platform-admin-password> \
+  <workbench-operator-bundle-package>
+```
+
+## Install the Workbench operator
 
 ### Procedure
 
 1. Go to the **Administrator** page.
-2. Click **Marketplace** > **Cluster Plugins** to enter the **Cluster Plugins** list page.
-3. Find the **Workbench** cluster plugin, click **Install**, and navigate to the **Workbench Plugin Install** page.
+2. Click **Marketplace** > **OperatorHub**.
+3. From the **Cluster** dropdown, select the business cluster where Workbench will run.
+4. Find **Alauda AI Workbench Operator** and click **Install**.
+5. Keep the `stable` channel and verify that the version is `v0.2.0`.
+6. Leave the installation location at its default and choose an upgrade strategy.
+7. Click **Install** and wait for the ClusterServiceVersion (CSV) status to become `Succeeded`.
+
+## Create a Workbench instance
+
+The operator does not deploy `workspace-controller` until you create a `Workbench` custom resource.
+
+1. Open the installed **Alauda AI Workbench Operator**.
+2. Select the **All instances** tab and click **Create**.
+3. Keep **Enable Istio integration** disabled unless the cluster runs ASM and you need Elyra-generated KFP run URLs to redirect through the Kubeflow Istio ingress gateway.
+4. Click **Create**.
+
+You can create the same resource with `kubectl`:
+
+```yaml
+apiVersion: workbench.alauda.io/v1alpha1
+kind: Workbench
+metadata:
+  name: workbench
+spec:
+  global:
+    istio:
+      enabled: false
+```
+
+Save the manifest as `workbench.yaml`, then apply it:
+
+```bash
+kubectl apply -f workbench.yaml
+```
+
+The operator reads the cluster name, ingress class, and image registry from the `kube-public/global-info` `ConfigMap`. You normally do not need to set those values in the `Workbench` resource.
+
+## Verification
+
+```bash
+# The Workbench custom resource exists.
+kubectl get workbench -A
+
+# The workspace-controller operand is available.
+kubectl -n kubeflow get deploy workspace-controller-controller-manager
+
+# Built-in IDE templates are registered.
+kubectl get workspacekind
+```
+
+After the deployment is ready, confirm that **Workbench** appears in Alauda AI and that you can open the Workbench list.
 
 ## Feature Gate Configuration
 
@@ -28,4 +95,3 @@ Access the feature gates at `{platform-access-address}/console-platform/feature-
 
 1. Find the gate list with the display name of your target which is `ai-workbench`.
 2. Turn On the switch button of it.
-

--- a/docs/en/installation/workbench.mdx
+++ b/docs/en/installation/workbench.mdx
@@ -4,7 +4,7 @@ weight: 15
 
 # Install Workbench
 
-Workbench v0.2.0 is delivered as an **OLM Helm operator**. Install the operator from **OperatorHub**, then create a `Workbench` custom resource that deploys and manages `workspace-controller` and the built-in JupyterLab and code-server `WorkspaceKind` resources.
+Starting with v0.2.0, Workbench is delivered as an **OLM Helm operator**. Install the operator from **OperatorHub**, then create a `Workbench` custom resource that deploys and manages `workspace-controller` and the built-in JupyterLab and code-server `WorkspaceKind` resources.
 
 ## Prerequisites
 
@@ -12,11 +12,11 @@ Workbench v0.2.0 is delivered as an **OLM Helm operator**. Install the operator 
 - Operator Lifecycle Manager (OLM) is available through the platform.
 - cert-manager is installed for the workspace-controller webhook certificate.
 - The separate `aml-skipper` component is installed for Workbench routing.
-- **Optional:** ASM (Istio) is required only for the Elyra Kubeflow Pipelines run-URL redirect. Workbench v0.2.0 disables Istio integration by default and can install without Istio CRDs.
+- **Optional:** ASM (Istio) is required only for the Elyra Kubeflow Pipelines run-URL redirect. Istio integration is disabled by default, so Workbench can install without Istio CRDs.
 
 ## Upload the operator
 
-Download the **Alauda AI Workbench Operator v0.2.0** bundle from the <Term name="company" /> Customer Portal / Marketplace. If it is not already available in OperatorHub, publish the downloaded bundle to the platform repository:
+Download the **Alauda AI Workbench Operator** bundle from the <Term name="company" /> Customer Portal / Marketplace. If it is not already available in OperatorHub, publish the downloaded bundle to the platform repository:
 
 ```bash
 violet push \

--- a/docs/en/mlflow/how_to/mlflow-python-sdk.mdx
+++ b/docs/en/mlflow/how_to/mlflow-python-sdk.mdx
@@ -8,7 +8,7 @@ On Alauda AI the [MLflow Tracking Server](../intro.mdx) runs behind single sign-
 
 There are two browser-free ways to present your identity; pick one:
 
-- **Bearer token (recommended).** Obtain a Dex **id token** from the CLI or Python and pass it as `MLFLOW_TRACKING_TOKEN`; renew it with the refresh token. Needs one platform setting ([below](#platform-setup)).
+- **Bearer token (recommended).** Obtain a Dex **id token** from the CLI or Python and pass it as `MLFLOW_TRACKING_TOKEN`; renew it with the refresh token. MLflow Operator v3.13.0 enables this method by default ([verify the setting below](#platform-setup)).
 - **Session cookie (no platform changes).** Drive the proxy's own login to obtain its `_oauth2_proxy` cookie and attach it to requests. Works on any install as-is ([below](#cookie-method)).
 
 ## How authentication works
@@ -22,23 +22,24 @@ The client always goes through the OAuth proxy — never connect to the MLflow c
 
 ## Prerequisites
 
-- `mlflow` **3.10 or later** (`pip install "mlflow>=3.10"`). Workspace selection (`mlflow.set_workspace`) is a 3.10+ feature. The Python token helper also uses `requests` and `cryptography`.
+- `mlflow` **3.13.0** (`pip install "mlflow==3.13.0"`), matching the client version validated with MLflow Operator v3.13.0. Workspace selection (`mlflow.set_workspace`) is available in this release. The Python token helper also uses `requests` and `cryptography`.
 - A platform **username and password** that can access the target workspace (see [Workspaces and access control](./workspaces.mdx)). This is an ordinary platform login — **not** a Kubernetes ServiceAccount — and a normal user account works. For shared or automated use (pipelines, headless jobs), prefer a **dedicated, non-personal account** over an individual's login, since the credentials/token are stored in a `Secret` and every run is recorded under whoever you authenticate as.
 - The platform's **OAuth client id and secret** — the client the MLflow proxy uses (from your administrator). On Alauda this is the platform auth client, e.g. `alauda-auth`; its secret lives in a Kubernetes `Secret` (e.g. `cpaas-oidc-secret`).
 
-## Platform setup for the token method (administrator, one-time) \{#platform-setup}
+## Verify the token method (administrator) \{#platform-setup}
 
-The bearer-token method needs the MLflow OAuth proxy to accept Dex id tokens. Add `--skip-jwt-bearer-tokens=true` to the **MLflow plugin** — this is the MLflow proxy on the workload cluster, **not** the platform's global auth server:
+MLflow Operator v3.13.0 configures the workload-cluster OAuth proxy to accept Dex id tokens by default. Verify the `MLflow` custom resource keeps this setting enabled:
 
 ```yaml
-# MLflow plugin values
-auth:
-  oauth:
-    extraArgs:
-      - --skip-jwt-bearer-tokens=true
+apiVersion: mlflow.alauda.io/v1alpha1
+kind: MLflow
+spec:
+  auth:
+    oauth:
+      skipJwtBearerTokens: true
 ```
 
-No Dex or global-auth change is required: the login below uses the `authorization_code` grant the platform client already allows. The **cookie method** needs no setting at all — skip this section if you use it.
+This is the MLflow proxy on the workload cluster, **not** the platform's global auth server. No Dex or global-auth change is required: the login below uses the `authorization_code` grant the platform client already allows. If you upgraded from an older release or replaced the default OAuth configuration, restore `skipJwtBearerTokens: true`. The **cookie method** needs no setting at all.
 
 ## Get a token from the command line (browser-free) \{#get-a-token}
 
@@ -160,7 +161,7 @@ Promote the registered version to **Staging** or **Production** from the MLflow 
 
 ## Alternative: session cookie (no platform changes) \{#cookie-method}
 
-If you cannot enable `--skip-jwt-bearer-tokens`, drive the proxy's own login flow to obtain its `_oauth2_proxy` cookie and attach it to requests — this works on any install unchanged. The proxy starts the OAuth flow for you (its own PKCE and `redirect_uri`); you just replay that through the same scripted login and hand the code back to the proxy callback:
+If you cannot enable `spec.auth.oauth.skipJwtBearerTokens`, drive the proxy's own login flow to obtain its `_oauth2_proxy` cookie and attach it to requests — this works on any install unchanged. The proxy starts the OAuth flow for you (its own PKCE and `redirect_uri`); you just replay that through the same scripted login and hand the code back to the proxy callback:
 
 ```bash
 PLATFORM=https://<platform>; CLUSTER=<cluster>
@@ -211,8 +212,8 @@ You can also copy the `_oauth2_proxy` cookie from a browser session (DevTools �
 | `/dex/api/v1/authorize` returns `PKCE code_challenge is required` | The client enforces PKCE. Send `code_challenge` and `code_challenge_method=S256` (the helper does this). |
 | Local login returns a captcha challenge / `CaptchaError` | Too many recent failed logins triggered the retry-captcha. Wait, fix the credentials, then retry — a clean first login needs no captcha. |
 | `/dex/token` returns `invalid_grant` | The auth code or PKCE verifier is stale or reused. Re-run the flow from the start (`authorize` → login → token); codes are single-use. |
-| Call returns HTML or a redirect (`302` to the login page) | **Token method:** the proxy rejected the bearer token — confirm `--skip-jwt-bearer-tokens` is enabled and the token is a valid Dex id token (`aud` = the proxy's client). **Cookie method:** the `_oauth2_proxy` cookie is missing or expired. |
+| Call returns HTML or a redirect (`302` to the login page) | **Token method:** the proxy rejected the bearer token — confirm `spec.auth.oauth.skipJwtBearerTokens` is `true` and the token is a valid Dex id token (`aud` = the proxy's client). **Cookie method:** the `_oauth2_proxy` cookie is missing or expired. |
 | `Invalid … character(s) in header value: 'Bearer …\n'` | The token has trailing whitespace. Set `MLFLOW_TRACKING_TOKEN` to the `.strip()`-ed value. |
-| `Failed to query /api/3.0/mlflow/server-info`, often with `SSLCertVerificationError: self-signed certificate` | The proxy **rejected** your credential and returned a `302` to the login page; the SDK then follows that redirect to the platform's self-signed HTTPS endpoint and fails TLS. Fix the credential, not the TLS: for the **token method** confirm `--skip-jwt-bearer-tokens` is enabled and the token is valid; for the **cookie method** re-mint the cookie. Only if you *intentionally* use the external `https://<platform>/…` route, also set `MLFLOW_TRACKING_INSECURE_TLS=true` (or point `REQUESTS_CA_BUNDLE` at the platform CA). |
+| `Failed to query /api/3.0/mlflow/server-info`, often with `SSLCertVerificationError: self-signed certificate` | The proxy **rejected** your credential and returned a `302` to the login page; the SDK then follows that redirect to the platform's self-signed HTTPS endpoint and fails TLS. Fix the credential, not the TLS: for the **token method** confirm `spec.auth.oauth.skipJwtBearerTokens` is `true` and the token is valid; for the **cookie method** re-mint the cookie. Only if you *intentionally* use the external `https://<platform>/…` route, also set `MLFLOW_TRACKING_INSECURE_TLS=true` (or point `REQUESTS_CA_BUNDLE` at the platform CA). |
 | `403 PERMISSION_DENIED` | Your account lacks access to the workspace namespace. Request access to the workspace (see [Workspaces and access control](./workspaces.mdx)); no ServiceAccount is involved. |
 | Run shows the wrong owner or workspace | The owner is your authenticated identity; the workspace is `set_workspace()` / `MLFLOW_WORKSPACE` (else the server default). Check both. |

--- a/docs/en/mlflow/how_to/mlflow-python-sdk.mdx
+++ b/docs/en/mlflow/how_to/mlflow-python-sdk.mdx
@@ -8,7 +8,7 @@ On Alauda AI the [MLflow Tracking Server](../intro.mdx) runs behind single sign-
 
 There are two browser-free ways to present your identity; pick one:
 
-- **Bearer token (recommended).** Obtain a Dex **id token** from the CLI or Python and pass it as `MLFLOW_TRACKING_TOKEN`; renew it with the refresh token. MLflow Operator v3.13.0 enables this method by default ([verify the setting below](#platform-setup)).
+- **Bearer token (recommended).** Obtain a Dex **id token** from the CLI or Python and pass it as `MLFLOW_TRACKING_TOKEN`; renew it with the refresh token. The operator enables this method by default ([verify the setting below](#platform-setup)).
 - **Session cookie (no platform changes).** Drive the proxy's own login to obtain its `_oauth2_proxy` cookie and attach it to requests. Works on any install as-is ([below](#cookie-method)).
 
 ## How authentication works
@@ -22,13 +22,13 @@ The client always goes through the OAuth proxy — never connect to the MLflow c
 
 ## Prerequisites
 
-- `mlflow` **3.13.0** (`pip install "mlflow==3.13.0"`), matching the client version validated with MLflow Operator v3.13.0. Workspace selection (`mlflow.set_workspace`) is available in this release. The Python token helper also uses `requests` and `cryptography`.
+- `mlflow` **3.13.0** (`pip install "mlflow==3.13.0"`), the client version validated for this release. Workspace selection (`mlflow.set_workspace`) is available in this release. The Python token helper also uses `requests` and `cryptography`.
 - A platform **username and password** that can access the target workspace (see [Workspaces and access control](./workspaces.mdx)). This is an ordinary platform login — **not** a Kubernetes ServiceAccount — and a normal user account works. For shared or automated use (pipelines, headless jobs), prefer a **dedicated, non-personal account** over an individual's login, since the credentials/token are stored in a `Secret` and every run is recorded under whoever you authenticate as.
 - The platform's **OAuth client id and secret** — the client the MLflow proxy uses (from your administrator). On Alauda this is the platform auth client, e.g. `alauda-auth`; its secret lives in a Kubernetes `Secret` (e.g. `cpaas-oidc-secret`).
 
 ## Verify the token method (administrator) \{#platform-setup}
 
-MLflow Operator v3.13.0 configures the workload-cluster OAuth proxy to accept Dex id tokens by default. Verify the `MLflow` custom resource keeps this setting enabled:
+Starting with MLflow Operator v3.13.0, the workload-cluster OAuth proxy accepts Dex id tokens by default. Verify the `MLflow` custom resource keeps this setting enabled:
 
 ```yaml
 apiVersion: mlflow.alauda.io/v1alpha1

--- a/docs/en/mlflow/how_to/pipelines-mlflow-integration.mdx
+++ b/docs/en/mlflow/how_to/pipelines-mlflow-integration.mdx
@@ -9,9 +9,9 @@ This guide shows how Kubeflow Pipelines (KFP) components log parameters, metrics
 ## Scope
 
 - Alauda AI 2.5 and later.
-- Kubeflow Pipelines and **MLflow Operator v3.13.0** are installed, and an `MLflow` custom resource is running.
+- Kubeflow Pipelines and the **MLflow Operator** are installed, and an `MLflow` custom resource is running.
 - The MLflow workspace is a namespace labelled `mlflow-enabled=true`.
-- For the bearer-token method, keep the v3.13.0 default `spec.auth.oauth.skipJwtBearerTokens: true` — see [Verify the token method](./mlflow-python-sdk.mdx#platform-setup) in the SDK guide. No global-auth change is needed, and the cookie method needs no setup at all.
+- For the bearer-token method, keep the default `spec.auth.oauth.skipJwtBearerTokens: true` — see [Verify the token method](./mlflow-python-sdk.mdx#platform-setup) in the SDK guide. No global-auth change is needed, and the cookie method needs no setup at all.
 
 ## Prerequisites
 
@@ -172,7 +172,7 @@ Each metric belongs to a `mlflow.start_run()` block. If a component has multiple
 
 ### Artifact storage for production
 
-Logging model artifacts requires durable object storage. MLflow Operator v3.13.0 supports proxied S3-compatible storage, so pipeline components can upload through the tracking server without receiving S3 credentials. Configure `artifacts.s3` before logging artifacts or registering models (see [MLflow installation → High availability and storage](../install.mdx#storage)).
+Proxied S3-compatible storage lets pipeline components upload through the tracking server without receiving S3 credentials. Configure `artifacts.s3` before logging artifacts or registering models (see [MLflow installation → High availability and storage](../install.mdx#storage)).
 
 ## Troubleshooting
 

--- a/docs/en/mlflow/how_to/pipelines-mlflow-integration.mdx
+++ b/docs/en/mlflow/how_to/pipelines-mlflow-integration.mdx
@@ -9,9 +9,9 @@ This guide shows how Kubeflow Pipelines (KFP) components log parameters, metrics
 ## Scope
 
 - Alauda AI 2.5 and later.
-- Kubeflow Pipelines and the MLflow cluster plugin are installed.
+- Kubeflow Pipelines and **MLflow Operator v3.13.0** are installed, and an `MLflow` custom resource is running.
 - The MLflow workspace is a namespace labelled `mlflow-enabled=true`.
-- For the bearer-token method, the MLflow OAuth proxy must accept Dex id tokens (`--skip-jwt-bearer-tokens`) — see [Platform setup](./mlflow-python-sdk.mdx#platform-setup) in the SDK guide. No global-auth change is needed, and the cookie method needs no setup at all.
+- For the bearer-token method, keep the v3.13.0 default `spec.auth.oauth.skipJwtBearerTokens: true` — see [Verify the token method](./mlflow-python-sdk.mdx#platform-setup) in the SDK guide. No global-auth change is needed, and the cookie method needs no setup at all.
 
 ## Prerequisites
 
@@ -38,7 +38,7 @@ from kfp import dsl, compiler
 from kfp import kubernetes
 
 
-@dsl.component(base_image="python:3.11-slim", packages_to_install=["mlflow>=3.10"])
+@dsl.component(base_image="python:3.11-slim", packages_to_install=["mlflow==3.13.0"])
 def train_model(
     workspace: str,
     model_name: str,
@@ -172,13 +172,13 @@ Each metric belongs to a `mlflow.start_run()` block. If a component has multiple
 
 ### Artifact storage for production
 
-Logging large model artifacts requires durable object storage. Configure S3-compatible storage in the MLflow settings (see [MLflow installation → High availability and storage](../install.mdx#storage)) so artifact uploads do not hit pod disk limits.
+Logging model artifacts requires durable object storage. MLflow Operator v3.13.0 supports proxied S3-compatible storage, so pipeline components can upload through the tracking server without receiving S3 credentials. Configure `artifacts.s3` before logging artifacts or registering models (see [MLflow installation → High availability and storage](../install.mdx#storage)).
 
 ## Troubleshooting
 
 | Symptom | Check |
 |---------|-------|
-| Component fails with an HTML/redirect (`302`) response | The OAuth proxy rejected the token. Confirm the proxy has `--skip-jwt-bearer-tokens` and `MLFLOW_TRACKING_TOKEN` is a valid Dex id token (see the [SDK guide](./mlflow-python-sdk.mdx)). |
+| Component fails with an HTML/redirect (`302`) response | The OAuth proxy rejected the token. Confirm `spec.auth.oauth.skipJwtBearerTokens` is `true` and `MLFLOW_TRACKING_TOKEN` is a valid Dex id token (see the [SDK guide](./mlflow-python-sdk.mdx)). |
 | `401 UNAUTHENTICATED` | `MLFLOW_TRACKING_TOKEN` is unset, empty, or expired — refresh the `mlflow-token` Secret. |
 | `403 PERMISSION_DENIED` | The token's user lacks access to the workspace namespace. Grant access to the MLflow workspace (see [Workspaces and access control](./workspaces.mdx)); no ServiceAccount is involved. |
 | Run shows up under the wrong owner / workspace | The owner is the token's identity; the workspace is `set_workspace()` (else the server default). Check both. |

--- a/docs/en/mlflow/install.mdx
+++ b/docs/en/mlflow/install.mdx
@@ -4,7 +4,7 @@ weight: 20
 
 # Installation
 
-MLflow v3.13.0 is delivered as an **OLM Operator** (the *MLflow Operator*) and installed from the platform **OperatorHub**. Installing the tracking server is a two-step flow: install the operator, then create one `MLflow` custom resource that reconciles the tracking-server stack.
+MLflow is delivered as an **OLM Operator** (the *MLflow Operator*) and installed from the platform **OperatorHub**. Installing the tracking server is a two-step flow: install the operator, then create one `MLflow` custom resource that reconciles the tracking-server stack.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ MLflow v3.13.0 is delivered as an **OLM Operator** (the *MLflow Operator*) and i
   ```
 
   Use a highly available PostgreSQL service for production (see [High availability and storage](#storage)).
-- **For production artifact storage, an existing S3-compatible bucket** in SeaweedFS, MinIO, Ceph RGW, or AWS S3. The v3.13.0 operator can proxy artifact access so clients do not need object-storage credentials. The in-pod filesystem default is suitable only for smoke tests.
+- **For production artifact storage, an existing S3-compatible bucket** in SeaweedFS, MinIO, Ceph RGW, or AWS S3. The operator can proxy artifact access so clients do not need object-storage credentials. The in-pod filesystem default is suitable only for smoke tests.
 - The platform **OAuth / OIDC provider** (provided by Alauda AI) — the OAuth proxy in front of the tracking server uses it for single sign-on.
 - **For multi-tenancy, the default workspace namespace must already exist and carry the label `mlflow-enabled=true` _before_ the tracking server first starts.** Otherwise the server crash-loops with `Workspace '<name>' not found in the Kubernetes cluster`.
 
@@ -153,7 +153,7 @@ Then open **Alauda AI → Tools → MLFlow**. The run owner and visible workspac
 ## High availability and storage \{#storage}
 
 - **Database.** MLflow stores all experiment/run/registry metadata in the external PostgreSQL you configured. Use a highly available PostgreSQL service for production; the tracking server itself is stateless with respect to metadata.
-- **Artifacts.** The default `artifacts.defaultArtifactRoot: /mlflow/artifacts` is an `emptyDir` local to the tracking-server pod. It is not durable, and external clients cannot use the server-local path reliably. For production, enable `artifacts.s3` before users log artifacts or register models. With the default `proxied: true`, the tracking server stores the S3 credentials and clients upload through the authenticated MLflow endpoint.
+- **Artifacts.** The default `artifacts.defaultArtifactRoot: /mlflow/artifacts` is an `emptyDir` local to the tracking-server pod. It is not durable, and external clients cannot use the server-local path reliably. Starting with v3.13.0, enable `artifacts.s3` for production before users log artifacts or register models. With the default `proxied: true`, the tracking server stores the S3 credentials and clients upload through the authenticated MLflow endpoint.
 - **Replicas.** The default deployment is single-replica. It is not a multi-replica high-availability deployment unless your release notes state otherwise.
 
 Create the referenced credentials Secret in the tracking-server namespace before applying the `MLflow` resource:
@@ -168,13 +168,13 @@ The bucket must already exist. Leave `endpointUrl` empty for AWS S3. For S3-comp
 
 ## Bearer-token clients \{#bearer-tokens}
 
-MLflow Operator v3.13.0 enables `spec.auth.oauth.skipJwtBearerTokens: true` by default, allowing the **MLflow Python SDK** to authenticate with a Dex **id token** through `MLFLOW_TRACKING_TOKEN`. If an existing installation overrides the OAuth settings, verify that this field remains enabled. See [Verify the token method](./how_to/mlflow-python-sdk.mdx#platform-setup) in the SDK guide. The browser session-cookie method also remains available.
+Starting with v3.13.0, the operator enables `spec.auth.oauth.skipJwtBearerTokens: true` by default, allowing the **MLflow Python SDK** to authenticate with a Dex **id token** through `MLFLOW_TRACKING_TOKEN`. If an existing installation overrides the OAuth settings, verify that this field remains enabled. See [Verify the token method](./how_to/mlflow-python-sdk.mdx#platform-setup) in the SDK guide. The browser session-cookie method also remains available.
 
-## Upgrade from v3.10.x
+## Upgrade from v3.10.x to v3.13.0
 
-MLflow Operator v3.13.0 supports upgrading from the v3.10.x operator line through the `stable` OLM channel. Before approving the upgrade, back up the PostgreSQL backend database and the S3 artifact bucket. The MLflow 3.10 to 3.13 backend-store schema migration runs automatically when the tracking server starts.
+The `stable` OLM channel supports this upgrade. Before approving it, back up the PostgreSQL backend database and the S3 artifact bucket. The backend-store schema migration runs automatically when the tracking server starts.
 
-After the upgrade, keep `spec.auth.kubernetes.authorizationMode: user_identity_token` and `spec.auth.oauth.skipJwtBearerTokens: true`. These are the v3.13.0 defaults and preserve the documented Dex bearer-token flow.
+After the upgrade, keep `spec.auth.kubernetes.authorizationMode: user_identity_token` and `spec.auth.oauth.skipJwtBearerTokens: true`. These defaults preserve the documented Dex bearer-token flow.
 
 ## Troubleshooting
 

--- a/docs/en/mlflow/install.mdx
+++ b/docs/en/mlflow/install.mdx
@@ -4,19 +4,20 @@ weight: 20
 
 # Installation
 
-MLflow is delivered as an **OLM Operator** (the *MLflow Operator*) and installed from the platform **OperatorHub**. Installing the tracking server is a two-step flow: install the operator, then create one `MLflow` custom resource that reconciles the tracking-server stack.
+MLflow v3.13.0 is delivered as an **OLM Operator** (the *MLflow Operator*) and installed from the platform **OperatorHub**. Installing the tracking server is a two-step flow: install the operator, then create one `MLflow` custom resource that reconciles the tracking-server stack.
 
 ## Prerequisites
 
 - **Alauda AI** installed on the target cluster. The operator and its images ship both `linux/amd64` and `linux/arm64`.
 - Operator Lifecycle Manager (OLM) available on the target cluster (provided by the platform).
-- **A PostgreSQL database** reachable from the cluster, holding a database named `mlflow` for MLflow metadata. Have the host, port, username, and password ready, and create the database before you install:
+- **A PostgreSQL 12 or later database** reachable from the cluster, holding a database named `mlflow` for MLflow metadata. Have the host, port, username, and password ready, and create the database before you install:
 
   ```sql
   CREATE DATABASE mlflow;
   ```
 
   Use a highly available PostgreSQL service for production (see [High availability and storage](#storage)).
+- **For production artifact storage, an existing S3-compatible bucket** in SeaweedFS, MinIO, Ceph RGW, or AWS S3. The v3.13.0 operator can proxy artifact access so clients do not need object-storage credentials. The in-pod filesystem default is suitable only for smoke tests.
 - The platform **OAuth / OIDC provider** (provided by Alauda AI) — the OAuth proxy in front of the tracking server uses it for single sign-on.
 - **For multi-tenancy, the default workspace namespace must already exist and carry the label `mlflow-enabled=true` _before_ the tracking server first starts.** Otherwise the server crash-loops with `Workspace '<name>' not found in the Kubernetes cluster`.
 
@@ -49,7 +50,7 @@ In the **Administrator** view:
 2. At the top of the console, from the **Cluster** dropdown, select the destination cluster.
 3. Search for and select **MLflow Operator**, then click **Install**.
 4. Leave **Channel** unchanged (`stable`).
-5. Check that the **Version** matches the release you want to install (e.g. `v3.10.2`).
+5. Check that the **Version** is `v3.13.0`.
 6. Leave **Installation Location** unchanged — it defaults to the `mlflow-operator` namespace.
 7. Choose an **Upgrade Strategy** (`Manual` is recommended for production).
 8. Click **Install**.
@@ -101,6 +102,16 @@ spec:
   # Run-artifact location (see High availability and storage below).
   artifacts:
     defaultArtifactRoot: /mlflow/artifacts
+    # Recommended for production. The bucket and Secret must already exist.
+    s3:
+      enabled: true
+      endpointUrl: https://object-storage.example.com
+      bucket: mlflow
+      prefix: production
+      existingSecret: mlflow-s3-credentials
+      accessKeyIdKey: AWS_ACCESS_KEY_ID
+      secretAccessKeyKey: AWS_SECRET_ACCESS_KEY
+      proxied: true
 ```
 
 Save as `mlflow.yaml` and apply:
@@ -119,7 +130,7 @@ On current versions the operator resolves cluster-specific values — the ingres
 2. From the **Cluster** dropdown at the top, select the target cluster.
 3. Open the installed **MLflow Operator**.
 4. Switch to the **All instances** tab and click **Create** (choose **MLflow** if prompted).
-5. Fill in the form, or switch to **YAML** view and paste the manifest from Method A. Set the PostgreSQL connection and, for multi-tenancy, the `defaultWorkspace` and label selector.
+5. Fill in the form, or switch to **YAML** view and paste the manifest from Method A. Set the PostgreSQL connection, the multi-tenancy workspace fields, and the S3 artifact-storage fields for production.
 6. Click **Create**.
 
 ## Verification
@@ -142,17 +153,34 @@ Then open **Alauda AI → Tools → MLFlow**. The run owner and visible workspac
 ## High availability and storage \{#storage}
 
 - **Database.** MLflow stores all experiment/run/registry metadata in the external PostgreSQL you configured. Use a highly available PostgreSQL service for production; the tracking server itself is stateless with respect to metadata.
-- **Artifacts.** The default `artifacts.defaultArtifactRoot: /mlflow/artifacts` is **local to the tracking-server pod** (an `emptyDir`) and is intended for development and testing only — it is not durable, and clients that upload large artifacts can hit pod disk limits. For production, configure an S3-compatible object store as the artifact root before users store experiment artifacts.
+- **Artifacts.** The default `artifacts.defaultArtifactRoot: /mlflow/artifacts` is an `emptyDir` local to the tracking-server pod. It is not durable, and external clients cannot use the server-local path reliably. For production, enable `artifacts.s3` before users log artifacts or register models. With the default `proxied: true`, the tracking server stores the S3 credentials and clients upload through the authenticated MLflow endpoint.
 - **Replicas.** The default deployment is single-replica. It is not a multi-replica high-availability deployment unless your release notes state otherwise.
 
-## Enable bearer-token clients (optional) \{#bearer-tokens}
+Create the referenced credentials Secret in the tracking-server namespace before applying the `MLflow` resource:
 
-By default the OAuth proxy accepts the browser session cookie. To let the **MLflow Python SDK** authenticate with a Dex **id token** (`MLFLOW_TRACKING_TOKEN`), the proxy must be configured to accept JWT bearer tokens (`--skip-jwt-bearer-tokens` / `OAUTH2_PROXY_SKIP_JWT_BEARER_TOKENS=true`). See [Platform setup for the token method](./how_to/mlflow-python-sdk.mdx#platform-setup) in the SDK guide. The cookie method needs no change.
+```bash
+kubectl -n kubeflow create secret generic mlflow-s3-credentials \
+  --from-literal=AWS_ACCESS_KEY_ID='<access-key>' \
+  --from-literal=AWS_SECRET_ACCESS_KEY='<secret-key>'
+```
+
+The bucket must already exist. Leave `endpointUrl` empty for AWS S3. For S3-compatible services, set it to the service endpoint. You can also set `region`, `ignoreTls`, and `prefix` under `artifacts.s3` when required.
+
+## Bearer-token clients \{#bearer-tokens}
+
+MLflow Operator v3.13.0 enables `spec.auth.oauth.skipJwtBearerTokens: true` by default, allowing the **MLflow Python SDK** to authenticate with a Dex **id token** through `MLFLOW_TRACKING_TOKEN`. If an existing installation overrides the OAuth settings, verify that this field remains enabled. See [Verify the token method](./how_to/mlflow-python-sdk.mdx#platform-setup) in the SDK guide. The browser session-cookie method also remains available.
+
+## Upgrade from v3.10.x
+
+MLflow Operator v3.13.0 supports upgrading from the v3.10.x operator line through the `stable` OLM channel. Before approving the upgrade, back up the PostgreSQL backend database and the S3 artifact bucket. The MLflow 3.10 to 3.13 backend-store schema migration runs automatically when the tracking server starts.
+
+After the upgrade, keep `spec.auth.kubernetes.authorizationMode: user_identity_token` and `spec.auth.oauth.skipJwtBearerTokens: true`. These are the v3.13.0 defaults and preserve the documented Dex bearer-token flow.
 
 ## Troubleshooting
 
 - If the **MLFlow** Tools-menu entry is missing, verify that the `aml-mlflow-menu-config` `ConfigMap` exists in the tracking-server namespace and has the label `aml.cpaas.io/centralMenuItem: "true"`.
 - If the server does not start and the pod logs `Workspace '<name>' not found`, the `defaultWorkspace` namespace does not exist or is not labelled `mlflow-enabled=true`. Create and label it, then restart the pod.
 - If the server does not start for another reason, verify PostgreSQL connectivity, that the `mlflow` database exists, and that the credentials in `spec.pg*` are correct.
+- If artifact uploads or model registration fail, verify that `artifacts.s3.enabled` is `true`, the bucket exists, and the referenced credentials Secret and key names are correct.
 - If a workspace is not visible, verify that its namespace matches the configured `workspaceLabelSelector`.
 - If requests are denied (`403 PERMISSION_DENIED`), check the user's Kubernetes `RoleBinding` in the workspace namespace — see [Workspaces and access control](./how_to/workspaces.mdx).

--- a/docs/en/mlflow/intro.mdx
+++ b/docs/en/mlflow/intro.mdx
@@ -6,8 +6,6 @@ weight: 10
 
 The **MLflow Operator** deploys and manages a multi-tenant **MLflow Tracking Server** on Alauda AI. Built on open-source [MLflow](https://mlflow.org), it gives data-science and ML teams a shared experiment-tracking and model-registry service that is integrated with the platform's single sign-on and Kubernetes RBAC — so each team only sees and manages its own runs, experiments, and registered models.
 
-This documentation describes **MLflow Operator v3.13.0**, which includes the MLflow 3.13.0 application, `mlflow-integration` 1.4.0, and S3-compatible artifact storage.
-
 MLflow is delivered as an **OLM Helm-based operator**. Installing the operator from the platform **OperatorHub** and creating a single `MLflow` custom resource stands up the tracking server, exposes it through the platform ingress, and adds an **MLFlow** entry to the **Alauda AI → Tools** menu.
 
 ## What it deploys

--- a/docs/en/mlflow/intro.mdx
+++ b/docs/en/mlflow/intro.mdx
@@ -6,6 +6,8 @@ weight: 10
 
 The **MLflow Operator** deploys and manages a multi-tenant **MLflow Tracking Server** on Alauda AI. Built on open-source [MLflow](https://mlflow.org), it gives data-science and ML teams a shared experiment-tracking and model-registry service that is integrated with the platform's single sign-on and Kubernetes RBAC — so each team only sees and manages its own runs, experiments, and registered models.
 
+This documentation describes **MLflow Operator v3.13.0**, which includes the MLflow 3.13.0 application, `mlflow-integration` 1.4.0, and S3-compatible artifact storage.
+
 MLflow is delivered as an **OLM Helm-based operator**. Installing the operator from the platform **OperatorHub** and creating a single `MLflow` custom resource stands up the tracking server, exposes it through the platform ingress, and adds an **MLFlow** entry to the **Alauda AI → Tools** menu.
 
 ## What it deploys

--- a/docs/en/workbench/overview/intro.mdx
+++ b/docs/en/workbench/overview/intro.mdx
@@ -8,6 +8,8 @@ weight: 10
 
 Workbench manages web IDE instances like Jupyter Notebooks, code-server, or RStudio. AI/ML developers and data scientists can use cluster resources (like GPUs) and connect to in-cluster services to create general ML jobs and pipelines.
 
+Workbench v0.2.0 is installed as an **OLM Helm operator**. A `Workbench` custom resource (`workbench.alauda.io/v1alpha1`) deploys and manages `workspace-controller` and the built-in IDE templates.
+
 Workbench uses "Kubeflow Notebook 2.0" as its backend to create cloud IDE containers. If you are familiar with "Kubeflow Notebook", it's easy to start using Workbench.
 
 Some key features include:

--- a/docs/en/workbench/overview/intro.mdx
+++ b/docs/en/workbench/overview/intro.mdx
@@ -8,7 +8,7 @@ weight: 10
 
 Workbench manages web IDE instances like Jupyter Notebooks, code-server, or RStudio. AI/ML developers and data scientists can use cluster resources (like GPUs) and connect to in-cluster services to create general ML jobs and pipelines.
 
-Workbench v0.2.0 is installed as an **OLM Helm operator**. A `Workbench` custom resource (`workbench.alauda.io/v1alpha1`) deploys and manages `workspace-controller` and the built-in IDE templates.
+Workbench is installed as an **OLM Helm operator**. A `Workbench` custom resource (`workbench.alauda.io/v1alpha1`) deploys and manages `workspace-controller` and the built-in IDE templates.
 
 Workbench uses "Kubeflow Notebook 2.0" as its backend to create cloud IDE containers. If you are familiar with "Kubeflow Notebook", it's easy to start using Workbench.
 

--- a/docs/en/workbench/upgrade.mdx
+++ b/docs/en/workbench/upgrade.mdx
@@ -4,6 +4,24 @@ weight: 16
 
 # Upgrade
 
+## Migrating from the Workbench Cluster Plugin to v0.2.0
+
+Workbench v0.2.0 changes its delivery form from a Cluster Plugin to an OLM Helm operator. There is **no in-place upgrade** between these forms.
+
+1. Back up the existing Workbench resources:
+
+   ```bash
+   kubectl get workspacekinds,workspaces -A -o yaml > workbench-backup.yaml
+   ```
+
+2. In **Administrator** > **Marketplace** > **Cluster Plugins**, uninstall the earlier **Workbench** cluster plugin. Preserve user PVCs, retained `WorkspaceKind` resources, and the `aml-workbench-config` `ConfigMap`; the operator adopts or reapplies these resources.
+3. Install **Alauda AI Workbench Operator v0.2.0** and create a `Workbench` custom resource as described in [Install Workbench](../installation/workbench.mdx).
+4. Verify the existing Workspaces and their PVCs are still present, then create and connect to a test Workbench.
+
+If the previous installation relied on the Elyra KFP run-URL redirect, set `spec.global.istio.enabled: true` in the `Workbench` custom resource. In v0.2.0, Istio integration is optional and disabled by default.
+
+## Migrating from Kubeflow Notebook
+
 Workbench is **NOT** compatible with "Kubeflow Notebook" (Alauda AI \<= 1.3). You need to create new "workbench" instances, the "Kubeflow Notebook" will be moved to "Advanced - Kubeflow" in the left navigation bar.
 
 :::warning

--- a/docs/en/workbench/upgrade.mdx
+++ b/docs/en/workbench/upgrade.mdx
@@ -4,9 +4,9 @@ weight: 16
 
 # Upgrade
 
-## Migrating from the Workbench Cluster Plugin to v0.2.0
+## Migrating from the Workbench Cluster Plugin
 
-Workbench v0.2.0 changes its delivery form from a Cluster Plugin to an OLM Helm operator. There is **no in-place upgrade** between these forms.
+Starting with v0.2.0, Workbench is delivered as an OLM Helm operator instead of a Cluster Plugin. There is **no in-place upgrade** between these forms.
 
 1. Back up the existing Workbench resources:
 
@@ -15,10 +15,10 @@ Workbench v0.2.0 changes its delivery form from a Cluster Plugin to an OLM Helm 
    ```
 
 2. In **Administrator** > **Marketplace** > **Cluster Plugins**, uninstall the earlier **Workbench** cluster plugin. Preserve user PVCs, retained `WorkspaceKind` resources, and the `aml-workbench-config` `ConfigMap`; the operator adopts or reapplies these resources.
-3. Install **Alauda AI Workbench Operator v0.2.0** and create a `Workbench` custom resource as described in [Install Workbench](../installation/workbench.mdx).
+3. Install the **Alauda AI Workbench Operator** and create a `Workbench` custom resource as described in [Install Workbench](../installation/workbench.mdx).
 4. Verify the existing Workspaces and their PVCs are still present, then create and connect to a test Workbench.
 
-If the previous installation relied on the Elyra KFP run-URL redirect, set `spec.global.istio.enabled: true` in the `Workbench` custom resource. In v0.2.0, Istio integration is optional and disabled by default.
+If the previous installation relied on the Elyra KFP run-URL redirect, set `spec.global.istio.enabled: true` in the `Workbench` custom resource. Istio integration is optional and disabled by default.
 
 ## Migrating from Kubeflow Notebook
 


### PR DESCRIPTION
## Summary

- update MLflow installation and usage docs for Operator/application v3.13.0
- document v3.13.0 S3-compatible artifact storage, bearer-token defaults, and v3.10.x upgrade guidance
- replace Workbench Cluster Plugin installation with the workspace-controller v0.2.0 OLM Helm operator flow
- add Workbench Cluster Plugin to operator migration guidance and optional Istio behavior

## Validation

- `yarn lint`
- `yarn build`