### PR TITLE
docs(mlflow): add agent tracing guide

### DIFF
--- a/docs/en/mlflow/how_to/agent-tracing.mdx
+++ b/docs/en/mlflow/how_to/agent-tracing.mdx
@@ -1,0 +1,210 @@
+---
+weight: 40
+---
+
+# Trace AI agents with MLflow
+
+MLflow Tracing records the steps an AI agent takes, including model requests and responses, chain and tool calls, retrieval steps, latency, token usage, and errors. On Alauda AI, traces are stored in the selected MLflow experiment and protected by the same workspace authentication and Kubernetes RBAC as runs and models.
+
+This guide shows the recommended tracing path for:
+
+- Python agents built with [LangChain](https://python.langchain.com/).
+- Applications that call [Llama Stack, now OGX](https://github.com/ogx-ai/ogx), through its OpenAI-compatible API.
+- OGX servers or other applications that already emit OpenTelemetry traces.
+
+## Prerequisites
+
+- An MLflow tracking server and a workspace you can access. See [Workspaces and access control](./workspaces.mdx).
+- A Dex id token in `MLFLOW_TRACKING_TOKEN`. Follow [Using the MLflow Python SDK with Authentication and RBAC](./mlflow-python-sdk.mdx#get-a-token) to obtain and renew one.
+- An experiment for the traces. Creating or writing traces requires `create` and `update` permission on the workspace's `experiments` resource.
+- Network access from the agent to the MLflow tracking server and its model endpoint.
+
+Set the common MLflow connection variables before starting the agent:
+
+```bash
+export MLFLOW_TRACKING_URI=http://mlflow-tracking-server.kubeflow:5000
+export MLFLOW_TRACKING_TOKEN='<dex-id-token>'
+export MLFLOW_WORKSPACE=team-a
+```
+
+The URI above is the in-cluster Service, fronted by the OAuth proxy. For a client outside the cluster, use `https://<platform>/clusters/<cluster>/mlflow` instead.
+
+:::warning
+Traces can contain prompts, responses, retrieved content, and tool arguments or results. Do not send secrets or sensitive personal data unless your organization permits storing that data in MLflow.
+:::
+
+## Trace a LangChain agent
+
+MLflow's LangChain integration automatically creates spans for the agent, nested chains, model requests, retrieval, and tool calls. It supports synchronous, asynchronous, batch, and streaming LangChain invocations.
+
+Install the agent dependencies:
+
+```bash
+pip install "mlflow[genai]" langchain langchain-openai
+```
+
+The following example uses a tool-calling agent and an OpenAI-compatible model endpoint. Set `MODEL_BASE_URL`, `MODEL_API_KEY`, and `MODEL_ID` for the model service available in your environment.
+
+```python
+import os
+
+import mlflow
+from langchain.agents import create_agent
+from langchain.tools import tool
+from langchain_openai import ChatOpenAI
+
+
+mlflow.set_experiment("agent-tracing")
+mlflow.langchain.autolog()
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Return the current weather for a city."""
+    # Replace this example result with a call to your weather service.
+    return f"The weather in {city} is sunny and 24 C."
+
+
+model = ChatOpenAI(
+    model=os.environ["MODEL_ID"],
+    base_url=os.environ["MODEL_BASE_URL"],
+    api_key=os.environ["MODEL_API_KEY"],
+)
+
+agent = create_agent(
+    model=model,
+    tools=[get_weather],
+    system_prompt="You are a concise travel assistant.",
+)
+
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Should I take a coat to Taipei today?"}]}
+)
+print(result["messages"][-1].content)
+```
+
+Call `mlflow.langchain.autolog()` once during application startup, before invoking the agent. Existing LangChain application code does not otherwise need to change.
+
+## Trace an OGX application
+
+OGX provides an OpenAI-compatible Chat Completions and Responses API. For a Python application that calls OGX, MLflow's OpenAI integration is the simplest option and fully traces Responses API calls.
+
+Install the client dependencies:
+
+```bash
+pip install "mlflow[genai]" openai
+```
+
+Point the OpenAI client at the OGX API. The `@mlflow.trace` wrapper groups all model and tool activity performed by `run_agent` under one parent span; `mlflow.openai.autolog()` creates the nested spans for each OGX request.
+
+```python
+import os
+
+import mlflow
+from openai import OpenAI
+
+
+mlflow.set_experiment("ogx-agent-tracing")
+mlflow.openai.autolog()
+
+client = OpenAI(
+    base_url=os.environ.get(
+        "OGX_BASE_URL",
+        "http://<ogx-service>.<namespace>.svc.cluster.local:8321/v1",
+    ),
+    api_key=os.environ.get("OGX_API_KEY", "not-used"),
+)
+
+
+@mlflow.trace(name="ogx-agent")
+def run_agent(question: str) -> str:
+    response = client.responses.create(
+        model=os.environ["OGX_MODEL_ID"],
+        input=question,
+    )
+    return response.output_text
+
+
+print(run_agent("Give me a two-step plan for testing a Kubernetes operator."))
+```
+
+Every call made inside a multi-step agent loop is nested under the `ogx-agent` trace. When the request uses function tools, MLflow also records the tool definitions and the model's tool-call response.
+
+## Export OGX OpenTelemetry traces
+
+Use OpenTelemetry when you want to trace the OGX server itself, instrument a non-Python application, or route telemetry through a collector. MLflow accepts traces over **OTLP/HTTP** at `/v1/traces`; it does not accept OTLP/gRPC ingestion.
+
+First, get the numeric experiment ID:
+
+```python
+import mlflow
+
+experiment = mlflow.set_experiment("ogx-server-tracing")
+print(experiment.experiment_id)
+```
+
+Configure an OpenTelemetry Collector to receive traces from OGX and forward them to Alauda MLflow:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  otlphttp/mlflow:
+    traces_endpoint: http://mlflow-tracking-server.kubeflow:5000/v1/traces
+    headers:
+      Authorization: "Bearer ${env:MLFLOW_TRACKING_TOKEN}"
+      X-MLflow-Experiment-Id: "${env:MLFLOW_EXPERIMENT_ID}"
+      X-MLFLOW-WORKSPACE: "${env:MLFLOW_WORKSPACE}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/mlflow]
+```
+
+Start the collector with `MLFLOW_TRACKING_TOKEN`, `MLFLOW_EXPERIMENT_ID`, and `MLFLOW_WORKSPACE` in its environment. Then configure OGX to send OTLP/HTTP traces to the collector:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+
+opentelemetry-instrument \
+  --traces_exporter otlp \
+  --metrics_exporter none \
+  --service_name ogx-server \
+  -- \
+  ogx run starter
+```
+
+OGX uses OpenTelemetry auto-instrumentation for server and supported SDK activity. MLflow's OTLP endpoint ingests traces only; route metrics to a metrics backend separately.
+
+:::note
+Do not enable MLflow autologging and a separate OpenTelemetry exporter for the same calls unless you deliberately configure them to share one tracer provider. Independent exporters can create duplicate traces. For OGX Responses API client calls, prefer `mlflow.openai.autolog()` because OpenTelemetry auto-instrumentation may not capture all Responses API operations.
+:::
+
+## View the traces
+
+1. Open **Alauda AI → Tools → MLFlow**.
+2. Select the same workspace and experiment configured by the application or collector.
+3. Open the experiment's **Traces** tab.
+4. Select a trace to inspect its span hierarchy, inputs and outputs, latency, token usage, tool calls, and errors.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| A request redirects to the login page or returns `401` | Confirm `MLFLOW_TRACKING_TOKEN` contains a current Dex id token and the MLflow OAuth proxy accepts bearer tokens. See [Verify the token method](./mlflow-python-sdk.mdx#platform-setup). |
+| `403 PERMISSION_DENIED` | The authenticated user needs access to the workspace and `create`/`update` permission on its `experiments` resource. |
+| No traces appear | Confirm the application and UI use the same tracking URI, workspace, experiment, and time range. Also ensure autologging is enabled before the agent is invoked. |
+| OTLP export returns `400` or `403` | Confirm the exporter uses OTLP/HTTP and sends `Authorization`, `X-MLflow-Experiment-Id`, and `X-MLFLOW-WORKSPACE` headers. |
+| The same request appears twice | Disable either MLflow autologging or the independent OpenTelemetry exporter for that request path. |
+| OGX Responses API calls are missing from OpenTelemetry traces | Trace the client with `mlflow.openai.autolog()`, which supports the Responses API. |

--- a/docs/en/mlflow/intro.mdx
+++ b/docs/en/mlflow/intro.mdx
@@ -12,7 +12,7 @@ MLflow is delivered as an **OLM Helm-based operator**. Installing the operator f
 
 When you create an `MLflow` custom resource, the operator reconciles one MLflow stack in the configured namespace (`kubeflow` by default):
 
-- **MLflow Tracking Server** — the experiment-tracking API and web UI: log parameters, metrics, and artifacts; browse runs; and manage the model registry (the target of the `mlflow` Python SDK).
+- **MLflow Tracking Server** — the experiment-tracking API and web UI: log parameters, metrics, artifacts, and AI-agent traces; browse runs and traces; and manage the model registry (the target of the `mlflow` Python SDK).
 - **OAuth proxy** (`oauth2-proxy`) — authenticates every request against the platform OIDC provider before it reaches MLflow. Clients always go through the proxy; they never connect to the MLflow container port directly.
 - **Kubernetes auth plugin** — inside the tracking server, reads the caller's identity from the forwarded token, records each run under that user, and authorizes the request against Kubernetes RBAC.
 - **Tools-menu entry and ingress route** — a `ConfigMap` that adds **MLFlow** to the Alauda AI **Tools** menu, plus an ingress route on the platform load balancer.
@@ -40,4 +40,4 @@ Workspace membership and permissions are therefore managed with ordinary Kuberne
 
 ## When to use it
 
-Use the MLflow Operator when teams need a shared, SSO-protected experiment-tracking and model-registry service where each team's runs and models are isolated by namespace and governed by Kubernetes RBAC — rather than an unauthenticated, single-tenant MLflow server.
+Use the MLflow Operator when teams need a shared, SSO-protected experiment-tracking, [AI-agent tracing](./how_to/agent-tracing.mdx), and model-registry service where each team's runs and models are isolated by namespace and governed by Kubernetes RBAC — rather than an unauthenticated, single-tenant MLflow server.

--- a/e2e/mlflow-agent-tracing.py
+++ b/e2e/mlflow-agent-tracing.py
@@ -1,0 +1,91 @@
+"""Invoke a LangChain agent and assert that MLflow stored its nested trace."""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import mlflow
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
+
+
+def configure_proxy_cookie() -> None:
+    if not os.environ.get("MLFLOW_PROXY_COOKIE"):
+        return
+
+    from mlflow.tracking.request_header.abstract_request_header_provider import (
+        RequestHeaderProvider,
+    )
+    from mlflow.tracking.request_header.registry import _request_header_provider_registry
+
+    class ProxyCookieHeader(RequestHeaderProvider):
+        def in_context(self) -> bool:
+            return True
+
+        def request_headers(self) -> dict[str, str]:
+            return {"Cookie": os.environ["MLFLOW_PROXY_COOKIE"]}
+
+    _request_header_provider_registry.register(ProxyCookieHeader)
+
+
+def main() -> None:
+    configure_proxy_cookie()
+
+    mlflow.set_tracking_uri(os.environ["MLFLOW_TRACKING_URI"])
+    mlflow.set_workspace(os.environ["MLFLOW_WORKSPACE"])
+
+    experiment_name = f"e2e-agent-tracing-{int(time.time())}-{uuid.uuid4().hex[:8]}"
+    experiment = mlflow.set_experiment(experiment_name)
+    client = mlflow.MlflowClient()
+
+    try:
+        mlflow.langchain.autolog(run_tracer_inline=True)
+        model = ChatOpenAI(
+            model=os.environ["AGENT_MODEL_ID"],
+            base_url=os.environ["AGENT_MODEL_BASE_URL"],
+            api_key=os.environ.get("AGENT_MODEL_API_KEY", "not-used"),
+            temperature=0,
+            max_tokens=64,
+        )
+        agent = create_agent(
+            model=model,
+            tools=[],
+            system_prompt="You are an e2e test agent. Reply briefly.",
+        )
+
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "Say that tracing is ready."}]}
+        )
+        if not result["messages"][-1].content:
+            raise AssertionError("agent returned an empty response")
+
+        traces = mlflow.search_traces(
+            locations=[experiment.experiment_id],
+            max_results=10,
+            return_type="list",
+            flush=True,
+        )
+        if len(traces) != 1:
+            raise AssertionError(f"expected one trace, found {len(traces)}")
+
+        trace = traces[0]
+        spans = trace.data.spans
+        if not any(span.name == "LangGraph" for span in spans):
+            raise AssertionError("trace does not contain the LangGraph agent span")
+        if not any(span.span_type == "CHAT_MODEL" for span in spans):
+            raise AssertionError("trace does not contain a chat-model span")
+
+        print(
+            "PASS: "
+            f"experiment_id={experiment.experiment_id} "
+            f"trace_id={trace.info.trace_id} "
+            f"spans={len(spans)}"
+        )
+    finally:
+        client.delete_experiment(experiment.experiment_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/mlflow-agent-tracing.sh
+++ b/e2e/mlflow-agent-tracing.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# E2E: invoke a LangChain agent and verify its MLflow trace.
+#
+# Connection (choose one):
+#   MLFLOW_TRACKING_URI     MLflow route, for example https://<platform>/clusters/x86/mlflow; or
+#   PLATFORM_ADDRESS, CLUSTER
+#                           values used to derive the MLflow route
+# Required:
+#   MLFLOW_WORKSPACE        target workspace namespace
+#   AGENT_MODEL_BASE_URL    OpenAI-compatible endpoint ending in /v1
+#   AGENT_MODEL_ID          model ID returned by the endpoint's /models API
+#
+# Authentication (choose one):
+#   MLFLOW_TRACKING_TOKEN   Dex id token accepted by the MLflow OAuth proxy; or
+#   MLFLOW_PROXY_COOKIE     existing _oauth2_proxy cookie; or
+#   PLATFORM_ADDRESS, CLUSTER, MLFLOW_USERNAME, MLFLOW_PASSWORD
+#                           credentials used to mint a temporary proxy cookie
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+source "${HERE}/lib.sh"
+
+require_env MLFLOW_WORKSPACE "workspace namespace for the trace experiment"
+require_env AGENT_MODEL_BASE_URL "OpenAI-compatible model endpoint ending in /v1"
+require_env AGENT_MODEL_ID "model ID returned by the endpoint's /models API"
+
+if [ -z "${MLFLOW_TRACKING_URI:-}" ]; then
+  require_env PLATFORM_ADDRESS "needed to derive MLFLOW_TRACKING_URI"
+  require_env CLUSTER "platform cluster name, for example x86"
+  export MLFLOW_TRACKING_URI="${PLATFORM_ADDRESS%/}/clusters/${CLUSTER}/mlflow"
+fi
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "${TMP}"; }
+trap cleanup EXIT
+umask 077
+
+# Local development environments can have a proxy configured for public
+# traffic. The platform route is internal and must be contacted directly.
+if [ -n "${PLATFORM_ADDRESS:-}" ]; then
+  PLATFORM_HOST="${PLATFORM_ADDRESS#*://}"
+  PLATFORM_HOST="${PLATFORM_HOST%%/*}"
+  PLATFORM_HOST="${PLATFORM_HOST%%:*}"
+  case ",${NO_PROXY:-}," in
+    *",${PLATFORM_HOST},"*) ;;
+    *) export NO_PROXY="${NO_PROXY:+${NO_PROXY},}${PLATFORM_HOST}" ;;
+  esac
+  export no_proxy="${NO_PROXY}"
+fi
+
+mint_proxy_cookie() {
+  require_env PLATFORM_ADDRESS "needed to mint an MLflow proxy session"
+  require_env CLUSTER "platform cluster name, for example x86"
+  require_env MLFLOW_USERNAME "platform username"
+  require_env MLFLOW_PASSWORD "platform password"
+
+  local platform route jar location query request public_key timestamp encrypted callback
+  platform="${PLATFORM_ADDRESS%/}"
+  route="${platform}/clusters/${CLUSTER}/mlflow"
+  jar="${TMP}/cookies"
+
+  location="$(curl -fsSk -c "${jar}" -D - -o /dev/null "${route}/" \
+    | awk 'BEGIN{IGNORECASE=1}/^location:/{print $2}' | tr -d '\r')"
+  query="${location#*\?}"
+  [ "${query}" != "${location}" ] || { log "MLflow route did not redirect to login"; return 1; }
+
+  request="$(curl -fsSk -b "${jar}" -c "${jar}" \
+    "${platform}/dex/api/v1/authorize?${query}" | jq -r '.req // empty')"
+  [ -n "${request}" ] || { log "Dex authorize response did not contain a request ID"; return 1; }
+
+  public_key="$(curl -fsSk "${platform}/dex/pubkey")"
+  timestamp="$(printf '%s' "${public_key}" | jq -r '.ts')"
+  printf '%s' "${public_key}" | jq -r '.pubkey' > "${TMP}/dex-public.pem"
+  encrypted="$(jq -nc --arg ts "${timestamp}" --arg password "${MLFLOW_PASSWORD}" \
+    '{ts:$ts,password:$password}' \
+    | openssl pkeyutl -encrypt -pubin -inkey "${TMP}/dex-public.pem" \
+        -pkeyopt rsa_padding_mode:pkcs1 \
+    | openssl base64 -A)"
+
+  callback="$(curl -fsSk -b "${jar}" -c "${jar}" -X POST \
+    "${platform}/dex/api/v1/authorize/local?req=${request}" \
+    -H 'Content-Type: application/json' \
+    --data "$(jq -nc --arg account "${MLFLOW_USERNAME}" --arg password "${encrypted}" \
+      '{account:$account,password:$password}')" \
+    | jq -r '.redirect_url // empty')"
+  [ -n "${callback}" ] || { log "Dex login did not return the MLflow proxy callback"; return 1; }
+
+  curl -fsSk -b "${jar}" -c "${jar}" -o /dev/null "${callback}"
+  MLFLOW_PROXY_COOKIE="$(awk -F'\t' '$6 ~ /^_oauth2_proxy/{printf "%s=%s; ",$6,$7}' "${jar}" \
+    | sed 's/; $//')"
+  [ -n "${MLFLOW_PROXY_COOKIE}" ] || { log "MLflow proxy session cookie was not created"; return 1; }
+  export MLFLOW_PROXY_COOKIE
+}
+
+if [ -z "${MLFLOW_TRACKING_TOKEN:-}" ] && [ -z "${MLFLOW_PROXY_COOKIE:-}" ]; then
+  log "minting a temporary MLflow proxy session"
+  mint_proxy_cookie
+fi
+
+export MLFLOW_TRACKING_INSECURE_TLS="${MLFLOW_TRACKING_INSECURE_TLS:-true}"
+
+command -v uv >/dev/null 2>&1 || { log "uv is required to run the isolated Python test"; exit 1; }
+
+log "running LangChain agent tracing test"
+uv run --no-project --python "${E2E_PYTHON:-3.12}" \
+  --with 'mlflow[genai]==3.13.0' \
+  --with 'langchain>=1,<2' \
+  --with 'langchain-openai>=1,<2' \
+  "${HERE}/mlflow-agent-tracing.py"


### PR DESCRIPTION
## Summary

- add a practical MLflow agent tracing guide for LangChain and Llama Stack/OGX applications
- document MLflow autologging for LangChain and the OGX OpenAI-compatible Responses API
- document authenticated OTLP/HTTP export for OGX server-side OpenTelemetry traces
- add an e2e case that invokes a LangChain agent and verifies LangGraph and chat-model spans in MLflow
- link agent tracing from the MLflow introduction

## Validation

- yarn lint
- yarn build
- bash syntax check
- Ruff Python check
- agent tracing e2e passed twice on the x86 dev cluster using the mlflow-e2e workspace and modelcar-qwen3-1.7b:v0.1.0
- git diff --check