### PR TITLE
docs(kagenti): add Envoy AI Gateway MCP example

### DIFF
--- a/docs/en/kagenti/examples/envoy_ai_gateway_mcp/01-mcp-servers.yaml
+++ b/docs/en/kagenti/examples/envoy_ai_gateway_mcp/01-mcp-servers.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: weather-mcp
+  namespace: kagenti-mcp-demo
+  labels:
+    app.kubernetes.io/name: weather-mcp
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: weather-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: weather-mcp
+        app.kubernetes.io/component: mcp-server
+    spec:
+      containers:
+        - name: mcp
+          image: ghcr.io/rossoctl/examples/weather_tool@sha256:6fd5d0b68792e3ddfb769bb974eb155a9bd1619792f79908b8aa70dc030d496f
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOST
+              value: 0.0.0.0
+            - name: PORT
+              value: "8000"
+            - name: UV_CACHE_DIR
+              value: /app/.cache/uv
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+          volumeMounts:
+            - name: cache
+              mountPath: /app/.cache
+            - name: tmp
+              mountPath: /tmp
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: weather
+  namespace: kagenti-mcp-demo
+  labels:
+    app.kubernetes.io/name: weather-mcp
+spec:
+  selector:
+    app.kubernetes.io/name: weather-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reservation-mcp
+  namespace: kagenti-mcp-demo
+  labels:
+    app.kubernetes.io/name: reservation-mcp
+    app.kubernetes.io/component: mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: reservation-mcp
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: reservation-mcp
+        app.kubernetes.io/component: mcp-server
+    spec:
+      containers:
+        - name: mcp
+          image: ghcr.io/rossoctl/examples/reservation_tool@sha256:b5fe4e947083d143e99fda2bde50cb99f8c70ed2d0a7c743ababca61cef22ecd
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOST
+              value: 0.0.0.0
+            - name: PORT
+              value: "8000"
+            - name: MCP_TRANSPORT
+              value: streamable-http
+            - name: UV_CACHE_DIR
+              value: /app/.cache/uv
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+          volumeMounts:
+            - name: cache
+              mountPath: /app/.cache
+            - name: tmp
+              mountPath: /tmp
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reservation
+  namespace: kagenti-mcp-demo
+  labels:
+    app.kubernetes.io/name: reservation-mcp
+spec:
+  selector:
+    app.kubernetes.io/name: reservation-mcp
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http

--- a/docs/en/kagenti/examples/envoy_ai_gateway_mcp/02-gateway.yaml
+++ b/docs/en/kagenti/examples/envoy_ai_gateway_mcp/02-gateway.yaml
@@ -1,0 +1,41 @@
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: kagenti-mcp-proxy
+  namespace: kagenti-mcp-demo
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        container:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+      envoyService:
+        name: kagenti-mcp-envoy
+        type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kagenti-mcp
+  namespace: kagenti-mcp-demo
+spec:
+  gatewayClassName: envoy-gateway-system-aieg
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: kagenti-mcp-proxy
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same

--- a/docs/en/kagenti/examples/envoy_ai_gateway_mcp/03-mcp-route-auth-rate-limit.yaml
+++ b/docs/en/kagenti/examples/envoy_ai_gateway_mcp/03-mcp-route-auth-rate-limit.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-client-api-keys
+  namespace: kagenti-mcp-demo
+type: Opaque
+stringData:
+  generic-agent: replace-this-demo-key
+---
+apiVersion: aigateway.envoyproxy.io/v1beta1
+kind: MCPRoute
+metadata:
+  name: kagenti-tools
+  namespace: kagenti-mcp-demo
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kagenti-mcp
+      sectionName: http
+  path: /mcp
+  backendRefs:
+    - name: weather
+      kind: Service
+      port: 8000
+      path: /mcp
+    - name: reservation
+      kind: Service
+      port: 8000
+      path: /mcp
+  securityPolicy:
+    apiKeyAuth:
+      credentialRefs:
+        - group: ""
+          kind: Secret
+          name: mcp-client-api-keys
+      extractFrom:
+        - params:
+            - api-key
+      forwardClientIDHeader: x-mcp-client-id
+      sanitize: true
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: kagenti-mcp-rate-limit
+  namespace: kagenti-mcp-demo
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: kagenti-mcp
+      sectionName: http
+  rateLimit:
+    local:
+      rules:
+        - clientSelectors:
+            - headers:
+                - name: x-mcp-client-id
+                  type: Distinct
+          limit:
+            requests: 30
+            unit: Minute

--- a/docs/en/kagenti/examples/envoy_ai_gateway_mcp/04-agent.yaml
+++ b/docs/en/kagenti/examples/envoy_ai_gateway_mcp/04-agent.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: generic-agent
+  namespace: kagenti-mcp-demo
+  labels:
+    app.kubernetes.io/name: generic-agent
+    protocol.kagenti.io/a2a: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-agent
+    spec:
+      containers:
+        - name: agent
+          image: ghcr.io/rossoctl/examples/generic_agent@sha256:54409772e7f33595fcb6488b7f343c3f2b82a692a0edba1d1ceacebb13262b11
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "8000"
+            - name: HOST
+              value: 0.0.0.0
+            - name: UV_CACHE_DIR
+              value: /app/.cache/uv
+            - name: MCP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-client-api-keys
+                  key: generic-agent
+            - name: MCP_URLS
+              value: http://kagenti-mcp-envoy.envoy-gateway-system.svc.cluster.local/mcp?api-key=$(MCP_API_KEY)
+            - name: MCP_TRANSPORT
+              value: streamable_http
+            - name: LLM_API_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: generic-agent-llm
+                  key: api-base
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: generic-agent-llm
+                  key: api-key
+            - name: LLM_MODEL
+              valueFrom:
+                secretKeyRef:
+                  name: generic-agent-llm
+                  key: model
+          ports:
+            - name: http
+              containerPort: 8000
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+          volumeMounts:
+            - name: cache
+              mountPath: /app/.cache
+            - name: tmp
+              mountPath: /tmp
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: generic-agent
+  namespace: kagenti-mcp-demo
+spec:
+  selector:
+    app.kubernetes.io/name: generic-agent
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+---
+apiVersion: agent.kagenti.dev/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: generic-agent
+  namespace: kagenti-mcp-demo
+spec:
+  type: agent
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: generic-agent

--- a/docs/en/kagenti/how_to/envoy_ai_gateway_mcp.mdx
+++ b/docs/en/kagenti/how_to/envoy_ai_gateway_mcp.mdx
@@ -1,0 +1,199 @@
+---
+weight: 30
+---
+
+# Kagenti with two MCP servers behind Envoy AI Gateway
+
+This example deploys the Rosso weather and restaurant-reservation MCP servers,
+aggregates them behind one Envoy Gateway data plane, and connects a Kagenti
+generic agent to the single `/mcp` endpoint.
+
+The manifests are in `docs/en/kagenti/examples/envoy_ai_gateway_mcp`. They
+target the `kagenti-mcp-demo` namespace. Before applying them, change the
+namespace and `GatewayClass` name if your environment uses different values.
+
+## Validated versions
+
+This example was validated on 2026-07-28 with:
+
+| Component | Version |
+| --- | --- |
+| Alauda Build of Envoy Gateway | `1.7.0-build.20260625161000` |
+| Alauda Build of Envoy AI Gateway | `0.6.0-1` |
+| `MCPRoute` API | `aigateway.envoyproxy.io/v1beta1` |
+
+Envoy AI Gateway 0.6 supports MCP aggregation, authentication, tool
+authorization, and upstream credentials through `MCPRoute`.
+
+Kuadrant `mcp-gateway` is not interchangeable with this API. Its controller
+creates an Istio `EnvoyFilter` and requires that resource before
+`MCPGatewayExtension` becomes ready. Envoy Gateway's native
+`EnvoyExtensionPolicy` does not expose the `mutation_rules.allow_all_routing`
+setting that Kuadrant MCP Gateway currently needs to rewrite `:authority`.
+Use the native Envoy AI Gateway `MCPRoute` shown here with Envoy Gateway, or use
+Kuadrant MCP Gateway with its supported Istio provider.
+
+## Topology and the HTTPRoute count
+
+```text
+Kagenti generic agent
+        |
+        | one authenticated MCP URL
+        v
+Envoy Gateway :80 /mcp
+        |
+        | Envoy AI Gateway MCP proxy
+        +-----------------------+
+        |                       |
+        v                       v
+weather:8000/mcp       reservation:8000/mcp
+```
+
+Author one `MCPRoute` with two `backendRefs`; do not author the backend
+`HTTPRoute`s by hand. The controller creates exactly two backend routes and
+one required client-facing route:
+
+- `ai-eg-mcp-br-kagenti-tools-weather`
+- `ai-eg-mcp-br-kagenti-tools-reservation`
+- `ai-eg-mcp-main-kagenti-tools`
+
+The first two are the requested per-server `HTTPRoute`s. The third exposes the
+unified `/mcp` endpoint. All three are owned by the `MCPRoute` and must not be
+edited directly.
+
+## Source and images
+
+The workloads come from
+[`rossoctl/examples`](https://github.com/rossoctl/examples) commit
+`ec17c73235c8ef291a6d4aaa346b50a4fba35e72`:
+
+- `mcp/weather_tool`
+- `mcp/reservation_tool`
+- `a2a/generic_agent`
+
+The YAML pins immutable multi-architecture image digests published at
+`ghcr.io/rossoctl/examples`.
+
+## Deploy the gateway and two MCP servers
+
+Create the example namespace if it does not exist:
+
+```bash
+kubectl create namespace kagenti-mcp-demo --dry-run=client -o yaml | kubectl apply -f -
+```
+
+Replace `replace-this-demo-key` in
+`03-mcp-route-auth-rate-limit.yaml` before using this outside a disposable dev
+environment. Then apply the server, gateway, and policy manifests:
+
+```bash
+EXAMPLE_DIR=docs/en/kagenti/examples/envoy_ai_gateway_mcp
+
+kubectl apply -f "$EXAMPLE_DIR/01-mcp-servers.yaml"
+kubectl apply -f "$EXAMPLE_DIR/02-gateway.yaml"
+kubectl apply -f "$EXAMPLE_DIR/03-mcp-route-auth-rate-limit.yaml"
+```
+
+The example uses API-key authentication and a local rate limit of 30 requests
+per minute for each authenticated client ID. `sanitize: true` removes the API
+key before the request is sent upstream. The generated client ID is forwarded
+as `x-mcp-client-id`, which is the rate-limit key.
+
+Verify the result:
+
+```bash
+kubectl -n kagenti-mcp-demo rollout status deploy/weather-mcp
+kubectl -n kagenti-mcp-demo rollout status deploy/reservation-mcp
+kubectl -n kagenti-mcp-demo get gateway kagenti-mcp
+kubectl -n kagenti-mcp-demo get mcproute kagenti-tools
+kubectl -n kagenti-mcp-demo get httproute
+```
+
+Expected conditions are `Gateway Programmed=True`, `MCPRoute Accepted`, and
+`Accepted=True` on all three generated `HTTPRoute`s.
+
+## Test the unified MCP endpoint
+
+Forward the stable Envoy Service created by `02-gateway.yaml`:
+
+```bash
+kubectl -n envoy-gateway-system \
+  port-forward service/kagenti-mcp-envoy 8080:80
+```
+
+In another terminal, initialize a session. Omitting the API key must return
+`401`; providing it must return an MCP response and an `mcp-session-id` header.
+
+```bash
+MCP_URL='http://127.0.0.1:8080/mcp?api-key=replace-this-demo-key'
+
+curl -i "$MCP_URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  --data '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+```
+
+Use the returned session ID to list tools:
+
+```bash
+SESSION_ID='<mcp-session-id>'
+
+curl -sS "$MCP_URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $SESSION_ID" \
+  --data '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+curl -sS "$MCP_URL" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -H "mcp-session-id: $SESSION_ID" \
+  --data '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' \
+  | sed -n 's/^data: //p' | jq
+```
+
+Tool names are prefixed with their backend, for example
+`weather__get_weather` and `reservation__search_restaurants`.
+
+## Deploy the Kagenti agent
+
+Create the LLM configuration Secret with an OpenAI-compatible endpoint:
+
+```bash
+kubectl -n kagenti-mcp-demo create secret generic generic-agent-llm \
+  --from-literal=api-base='https://your-openai-compatible-endpoint/v1' \
+  --from-literal=api-key='replace-me' \
+  --from-literal=model='replace-me'
+
+kubectl apply -f docs/en/kagenti/examples/envoy_ai_gateway_mcp/04-agent.yaml
+
+kubectl -n kagenti-mcp-demo get agentruntime generic-agent
+kubectl -n kagenti-mcp-demo rollout status deploy/generic-agent
+```
+
+`MCP_URLS` contains only the unified Envoy endpoint, so the agent discovers
+both tool sets through one MCP connection. The generic agent currently exposes
+only URL configuration, not per-server request headers; the example therefore
+uses an API key query parameter. The agent logs `MCP_URLS` during startup, so
+use this only for development. For production, add header-based MCP client
+configuration to the agent or use Kagenti AuthBridge with OAuth/JWT and switch
+the `MCPRoute` to `securityPolicy.oauth`.
+
+Try prompts such as:
+
+- `What is the weather in Taipei?`
+- `Find Italian restaurants in Boston.`
+
+## Cleanup
+
+The generated `HTTPRoute`s are deleted with the `MCPRoute`:
+
+```bash
+EXAMPLE_DIR=docs/en/kagenti/examples/envoy_ai_gateway_mcp
+
+kubectl delete -f "$EXAMPLE_DIR/04-agent.yaml" --ignore-not-found
+kubectl delete -f "$EXAMPLE_DIR/03-mcp-route-auth-rate-limit.yaml"
+kubectl delete -f "$EXAMPLE_DIR/02-gateway.yaml"
+kubectl delete -f "$EXAMPLE_DIR/01-mcp-servers.yaml"
+kubectl -n kagenti-mcp-demo delete secret generic-agent-llm --ignore-not-found
+```


### PR DESCRIPTION
## Summary

- document a Kagenti agent using two MCP servers through one Envoy AI Gateway
- add deployable manifests for the public Rosso weather, reservation, and generic-agent images
- configure MCPRoute API-key authentication and per-client rate limiting
- explain the generated HTTPRoute topology and the current Kuadrant/Istio compatibility boundary

## Validation

- `yarn lint`
- `yarn build`
- parsed all four example manifests as YAML
- verified all pinned public GHCR digests resolve anonymously for linux/amd64 and linux/arm64
- scanned the guide and manifests for internal registry, cluster, and telemetry references
- live validation covered unauthenticated 401 responses, authenticated MCP initialization, tool discovery, tool invocation, and rate-limit headers