### PR TITLE
docs: add ARM support for Kubeflow Pipelines

### DIFF
--- a/docs/en/learn/supported-configurations-for-2.x.md
+++ b/docs/en/learn/supported-configurations-for-2.x.md
@@ -28,9 +28,10 @@ This page lists the currently maintained Alauda AI versions in the component mat
 | Alauda Build of JobSet (1)                   | Operator       | -                                  | v0.12.0                          |
 | Volcano                                      | Cluster Plugin | v1.12.4                            | v1.12.4                          |
 | MLFlow                                       | Cluster Plugin | v3.1.5                             | v3.10.0                          |
-| Kubeflow Base                                | Cluster Plugin | v1.10.14-1                         | v1.11.0                          |
-| Kubeflow Pipelines (2)                       | Cluster Plugin | v1.10.13                           | v1.11.0                          |
-| Kubeflow Trainer v2 (1)                      | Cluster Plugin | v1.10.13                           | v1.11.0                          |
+| Kubeflow Base                                | Operator       | v1.10.14-1                         | v26.3.2                          |
+| Kubeflow Pipelines                           | Operator       | v1.10.13                           | v26.3.2                          |
+| Kubeflow Trainer v2 (1)                      | Operator       | v1.10.13                           | v26.3.2                          |
+| Data Science Pipeline Operator               | Operator       | v2.15.1                            | v2.15.1                          |
 | Alauda Build of Kubeflow Model Registry      | Operator       | v1.10.13                           | v0.3.8-2                         |
 | Alauda Build of Llama Stack                  | Operator       | v0.8.0                             | v0.9.0                           |
 | Label Studio                                 | Helm Charts    | v1.21.0-2                          | v1.21.0-2                        |
@@ -69,9 +70,10 @@ This page lists the currently maintained Alauda AI versions in the component mat
 | Alauda Build of JobSet (1)                   | Operator       | -                                  | v0.12.0                          |
 | Volcano                                      | Cluster Plugin | v1.12.4                            | v1.12.4                          |
 | MLFlow                                       | Cluster Plugin | v3.1.5                             | v3.10.0                          |
-| Kubeflow Base                                | Cluster Plugin | v1.10.14-1                         | v1.11.0                          |
-| Kubeflow Pipelines (2)                       | Cluster Plugin | v1.10.13                           | v1.11.0                          |
-| Kubeflow Trainer v2 (1)                      | Cluster Plugin | v1.10.13                           | v1.11.0                          |
+| Kubeflow Base                                | Operator       | v1.10.14-1                         | v26.3.2                          |
+| Kubeflow Pipelines                           | Operator       | v1.10.13                           | v26.3.2                          |
+| Kubeflow Trainer v2 (1)                      | Operator       | v1.10.13                           | v26.3.2                          |
+| Data Science Pipeline Operator               | Operator       | v2.15.1                            | v2.15.1                          |
 | Alauda Build of Kubeflow Model Registry      | Operator       | v1.10.13                           | v0.3.8-2                         |
 | Alauda build of Llama Stack                  | Operator       | v0.8.0                             | v0.9.0                           |
 | Label Studio                                 | Helm Charts    | v1.21.0-2                          | v1.21.0-2                        |

--- a/docs/en/learn/supported-configurations-for-2.x.md
+++ b/docs/en/learn/supported-configurations-for-2.x.md
@@ -70,6 +70,7 @@ This page lists the currently maintained Alauda AI versions in the component mat
 | Volcano                                      | Cluster Plugin | v1.12.4                            | v1.12.4                          |
 | MLFlow                                       | Cluster Plugin | v3.1.5                             | v3.10.0                          |
 | Kubeflow Base                                | Cluster Plugin | v1.10.14-1                         | v1.11.0                          |
+| Kubeflow Pipelines (2)                       | Cluster Plugin | v1.10.13                           | v1.11.0                          |
 | Kubeflow Trainer v2 (1)                      | Cluster Plugin | v1.10.13                           | v1.11.0                          |
 | Alauda Build of Kubeflow Model Registry      | Operator       | v1.10.13                           | v0.3.8-2                         |
 | Alauda build of Llama Stack                  | Operator       | v0.8.0                             | v0.9.0                           |
@@ -90,7 +91,7 @@ This page lists the currently maintained Alauda AI versions in the component mat
 
 (1) 'Kubeflow Trainer v2' and 'Alauda Build of JobSet' require Alauda Container Platform 4.1.x or later
 
-(2) 'Featureform' and 'Kubeflow Pipelines' are only supported on x86_64 architecture
+(2) 'Featureform' is only supported on x86_64 architecture
 
 (3) 'Alauda Build of NPU Operator' is only supported on ARM architecture
 


### PR DESCRIPTION
## Summary
- add Kubeflow Pipelines support to the ARM architecture matrix
- list Kubeflow Base, Kubeflow Pipelines, and Kubeflow Trainer v2 as Operators at v26.3.2 for Alauda AI v2.7
- add Data Science Pipeline Operator v2.15.1 for Alauda AI v2.3 and v2.7 on x86_64 and ARM
- clarify that only Featureform remains x86_64-only

## Validation
- npm run lint