### PR TITLE
docs: add YOLOv5 Trainer v2 and Triton guide

### DIFF
--- a/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml
+++ b/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml
@@ -1,6 +1,6 @@
 # Create this Secret and ServiceAccount in the namespace that runs both the
-# TrainJob and the InferenceService. For an HTTP endpoint, change s3-usehttps
-# to "0" and keep the http:// scheme in AWS_S3_ENDPOINT.
+# TrainJob and the InferenceService. Do not commit populated credentials. Use
+# HTTPS in production; change s3-usehttps to "0" only for a private test endpoint.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,6 +13,7 @@ metadata:
     serving.kserve.io/s3-usehttps: "1"
 type: Opaque
 stringData:
+  # Use a credential limited to the input prefixes and this run's output prefix.
   AWS_ACCESS_KEY_ID: <access-key>
   AWS_SECRET_ACCESS_KEY: <secret-key>
   # The AWS CLI in the training image uses a complete endpoint URL.

--- a/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml
+++ b/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml
@@ -1,0 +1,28 @@
+# Create this Secret and ServiceAccount in the namespace that runs both the
+# TrainJob and the InferenceService. For an HTTP endpoint, change s3-usehttps
+# to "0" and keep the http:// scheme in AWS_S3_ENDPOINT.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: yolov5-s3-credentials
+  namespace: <your-namespace>
+  annotations:
+    # KServe expects the endpoint without an http:// or https:// scheme.
+    serving.kserve.io/s3-endpoint: <s3-host>:<s3-port>
+    serving.kserve.io/s3-region: us-east-1
+    serving.kserve.io/s3-usehttps: "1"
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: <access-key>
+  AWS_SECRET_ACCESS_KEY: <secret-key>
+  # The AWS CLI in the training image uses a complete endpoint URL.
+  AWS_S3_ENDPOINT: https://<s3-host>:<s3-port>
+  AWS_DEFAULT_REGION: us-east-1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: yolov5-s3
+  namespace: <your-namespace>
+secrets:
+  - name: yolov5-s3-credentials

--- a/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   containers:
     - name: kserve-container
-      image: alaudadockerhub/tritonserver:25.02-py3
+      # Use an approved internal mirror and pin it by digest in production.
+      image: <your-registry>/tritonserver:25.02-py3
       command:
         - /bin/bash
         - -c
@@ -37,6 +38,8 @@ spec:
         privileged: false
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       startupProbe:
         httpGet:
           path: /v2/models/{{ index .Annotations "aml-model-repo" }}/ready

--- a/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml
@@ -1,0 +1,50 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: aml-triton-cuda-12
+  annotations:
+    cpaas.io/display-name: triton-cuda12-x86
+  labels:
+    cpaas.io/accelerator-type: nvidia
+    cpaas.io/cuda-version: "12.1"
+    cpaas.io/runtime-class: triton
+spec:
+  containers:
+    - name: kserve-container
+      image: alaudadockerhub/tritonserver:25.02-py3
+      command:
+        - /bin/bash
+        - -c
+        - >
+          tritonserver --log-verbose=1 --http-port=8080
+          --model-repository=/mnt/models
+      env:
+        - name: OMP_NUM_THREADS
+          value: "1"
+        - name: MODEL_REPO
+          value: '{{ index .Annotations "aml-model-repo" }}'
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+      startupProbe:
+        httpGet:
+          path: /v2/models/{{ index .Annotations "aml-model-repo" }}/ready
+          port: 8080
+          scheme: HTTP
+        failureThreshold: 60
+        periodSeconds: 10
+        timeoutSeconds: 10
+  supportedModelFormats:
+    - name: triton
+      version: "1"

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascend-inferenceservice.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascend-inferenceservice.yaml
@@ -1,0 +1,40 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: yolov5-coco128-ascend
+  namespace: <your-namespace>
+  annotations:
+    # This value must match TRITON_MODEL_NAME in the TrainJob.
+    aml-model-repo: yolov5-coco128
+    aml-pipeline-tag: object-detection
+    serving.kserve.io/deploymentMode: Standard
+  labels:
+    aml.cpaas.io/runtime-type: pytorch-ascend
+spec:
+  predictor:
+    minReplicas: 1
+    maxReplicas: 1
+    serviceAccountName: yolov5-s3
+    model:
+      name: ""
+      modelFormat:
+        name: pytorch
+      protocolVersion: v2
+      runtime: aml-yolov5-ascend-cann-8.5
+      # This URI must exactly match OUTPUT_MODEL_URI in the TrainJob.
+      storageUri: s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1
+      resources:
+        requests:
+          cpu: "2"
+          memory: 6Gi
+        limits:
+          cpu: "2"
+          memory: 6Gi
+          huawei.com/Ascend910B4: "1"
+          huawei.com/Ascend910B4-memory: "8192"
+    securityContext:
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+      supplementalGroups:
+        - 1000

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml
@@ -1,0 +1,67 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: aml-yolov5-ascend-cann-8.5
+  annotations:
+    cpaas.io/display-name: yolov5-ascend-cann8.5
+  labels:
+    cpaas.io/accelerator-type: ascend
+    cpaas.io/cann-version: "8.5"
+    cpaas.io/runtime-class: pytorch-ascend
+spec:
+  containers:
+    - name: kserve-container
+      # Build this image from yolov5-ascend.Containerfile and serve.py.
+      image: <your-registry>/yolov5-ascend:cann8.5
+      command:
+        - bash
+        - -c
+        - |
+          set -e
+          source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          source /usr/local/Ascend/nnal/atb/set_env.sh 2>/dev/null || true
+          exec uvicorn serve:app --app-dir /opt/yolov5 --host 0.0.0.0 --port 8080
+      env:
+        - name: MODEL_NAME
+          value: '{{ index .Annotations "aml-model-repo" }}'
+        - name: MODEL_PATH
+          value: /mnt/models/1/model.pt
+        - name: NPU_DEVICE
+          value: npu:0
+        - name: HOME
+          value: /tmp
+        - name: USER
+          value: yolo
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        httpGet:
+          path: /v2/models/{{ index .Annotations "aml-model-repo" }}/ready
+          port: 8080
+          scheme: HTTP
+        failureThreshold: 60
+        periodSeconds: 10
+        timeoutSeconds: 10
+  protocolVersions:
+    - v2
+  supportedModelFormats:
+    - name: pytorch
+      version: "1"

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   containers:
     - name: kserve-container
-      # Build this image from yolov5-ascend.Containerfile and serve.py.
+      # Build this image from yolov5-ascend.Containerfile and yolov5_ascend_server.py.
+      # Use an approved internal mirror and pin it by digest in production.
       image: <your-registry>/yolov5-ascend:cann8.5
       command:
         - bash

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile
@@ -1,0 +1,11 @@
+FROM docker.io/alaudadockerhub/torch2.6-cann8.5-arm64:v0.1.0
+
+USER 0
+RUN pip install --no-cache-dir \
+      fastapi==0.115.6 \
+      "uvicorn[standard]==0.34.0"
+
+COPY --chown=1000:1000 yolov5_ascend_server.py /opt/yolov5/serve.py
+RUN chmod 0555 /opt/yolov5/serve.py
+
+USER 1000

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile
@@ -1,4 +1,5 @@
-FROM docker.io/alaudadockerhub/torch2.6-cann8.5-arm64:v0.1.0
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 USER 0
 RUN pip install --no-cache-dir \

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-inferenceservice.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-inferenceservice.yaml
@@ -1,0 +1,41 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: yolov5-coco128
+  namespace: <your-namespace>
+  annotations:
+    # This value must match TRITON_MODEL_NAME in the TrainJob and config.pbtxt.
+    aml-model-repo: yolov5-coco128
+    aml-pipeline-tag: object-detection
+    serving.kserve.io/deploymentMode: Standard
+  labels:
+    aml.cpaas.io/runtime-type: triton
+spec:
+  predictor:
+    minReplicas: 1
+    maxReplicas: 1
+    serviceAccountName: yolov5-s3
+    model:
+      name: ""
+      modelFormat:
+        name: triton
+      protocolVersion: v2
+      runtime: aml-triton-cuda-12
+      # This URI must exactly match OUTPUT_MODEL_URI in the TrainJob.
+      storageUri: s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1
+      resources:
+        requests:
+          cpu: "2"
+          memory: 6Gi
+          nvidia.com/gpualloc: "1"
+          nvidia.com/gpucores: "50"
+          nvidia.com/gpumem: "8192"
+        limits:
+          cpu: "2"
+          memory: 6Gi
+          nvidia.com/gpualloc: "1"
+          nvidia.com/gpucores: "50"
+          nvidia.com/gpumem: "8192"
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
@@ -45,46 +45,24 @@ spec:
                         - |
                           set -euo pipefail
 
-                          : "${BASE_MODEL_URL:?Set BASE_MODEL_URL}"
-                          : "${DATASET_URL:?Set DATASET_URL}"
-                          : "${OUTPUT_MODEL_URL:?Set OUTPUT_MODEL_URL}"
-                          : "${OUTPUT_MODEL_BRANCH:?Set OUTPUT_MODEL_BRANCH}"
-                          : "${GIT_USER:?Set GIT_USER}"
-                          : "${GIT_TOKEN:?Set GIT_TOKEN}"
+                          : "${BASE_MODEL_URI:?Set BASE_MODEL_URI}"
+                          : "${DATASET_URI:?Set DATASET_URI}"
+                          : "${OUTPUT_MODEL_URI:?Set OUTPUT_MODEL_URI}"
+                          : "${TRITON_MODEL_NAME:?Set TRITON_MODEL_NAME}"
+                          : "${AWS_S3_ENDPOINT:?Set AWS_S3_ENDPOINT}"
 
                           WORKSPACE=/workspace
                           MODEL_DIR="${WORKSPACE}/yolov5"
                           DATASET_DIR="${WORKSPACE}/datasets/coco128"
                           TRAIN_DIR="${WORKSPACE}/runs/train"
                           TRITON_MODEL_DIR="${WORKSPACE}/triton-model"
-                          BASE_MODEL_URL_NO_HTTPS="${BASE_MODEL_URL#https://}"
-                          DATASET_URL_NO_HTTPS="${DATASET_URL#https://}"
-                          OUTPUT_MODEL_URL_NO_HTTPS="${OUTPUT_MODEL_URL#https://}"
-                          OUTPUT_MODEL_NAME="$(basename "${OUTPUT_MODEL_URL%.git}")"
-
                           # Download the YOLOv5 source, pretrained weight, and dataset from
-                          # the model repositories. Git LFS is required for the images and .pt files.
-                          cat > /tmp/git-askpass <<'EOF'
-                          #!/bin/sh
-                          case "$1" in
-                            *Username*) printf '%s\n' "${GIT_USER}" ;;
-                            *Password*) printf '%s\n' "${GIT_TOKEN}" ;;
-                          esac
-                          EOF
-                          chmod 700 /tmp/git-askpass
-                          export GIT_ASKPASS=/tmp/git-askpass
-                          export GIT_TERMINAL_PROMPT=0
-
-                          GIT_LFS_SKIP_SMUDGE=1 git clone \
-                            "https://${BASE_MODEL_URL_NO_HTTPS}" \
-                            "${MODEL_DIR}"
-                          (cd "${MODEL_DIR}" && git lfs pull)
-
+                          # S3-compatible object storage. The TrainJob supplies the AWS credentials.
+                          aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
+                            "${BASE_MODEL_URI}" "${MODEL_DIR}"
                           mkdir -p "${WORKSPACE}/datasets"
-                          GIT_LFS_SKIP_SMUDGE=1 git clone \
-                            "https://${DATASET_URL_NO_HTTPS}" \
-                            "${DATASET_DIR}"
-                          (cd "${DATASET_DIR}" && git lfs pull)
+                          aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
+                            "${DATASET_URI}" "${DATASET_DIR}"
 
                           cd "${MODEL_DIR}"
                           python train.py \
@@ -113,7 +91,7 @@ spec:
                           cp "${TRAIN_DIR}/weights/best.torchscript" \
                             "${TRITON_MODEL_DIR}/1/model.pt"
                           cat > "${TRITON_MODEL_DIR}/config.pbtxt" <<EOF
-                          name: "${OUTPUT_MODEL_NAME}"
+                          name: "${TRITON_MODEL_NAME}"
                           platform: "pytorch_libtorch"
                           max_batch_size: 8
                           input [
@@ -134,22 +112,12 @@ spec:
                           cat > "${TRITON_MODEL_DIR}/README.md" <<EOF
                           # YOLOv5 Triton model
 
-                          Fine-tuned from ${BASE_MODEL_URL} using ${DATASET_URL}.
+                          Fine-tuned from ${BASE_MODEL_URI} using ${DATASET_URI}.
                           EOF
 
-                          # Publish the model artifact to the output model repository on a new branch.
-                          cd "${TRITON_MODEL_DIR}"
-                          git init
-                          git checkout -b "${OUTPUT_MODEL_BRANCH}"
-                          git lfs track "1/model.pt"
-                          git add .
-                          git -c user.name='AMLSystemUser' \
-                            -c user.email='aml_admin@cpaas.io' \
-                            commit -m 'Publish fine-tuned YOLOv5 Triton model'
-                          git remote add origin "https://${OUTPUT_MODEL_URL_NO_HTTPS}"
-                          git -c http.sslVerify=false -c lfs.activitytimeout=36000 \
-                            push --set-upstream origin "${OUTPUT_MODEL_BRANCH}"
-                          rm -f /tmp/git-askpass
+                          # Upload the deployable Triton artifact layout to a new, immutable S3 prefix.
+                          aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
+                            "${TRITON_MODEL_DIR}" "${OUTPUT_MODEL_URI}"
                       volumeMounts:
                         - name: workspace
                           mountPath: /workspace

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
@@ -36,7 +36,7 @@ spec:
                         sizeLimit: 2Gi
                   containers:
                     - name: node
-                      # Replace with the image built in the guide.
+                      # Replace with the image built in the guide. Pin by digest in production.
                       image: <your-registry>/yolov5-trainer:v7.0
                       imagePullPolicy: IfNotPresent
                       command:

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
@@ -1,0 +1,164 @@
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainingRuntime
+metadata:
+  name: yolov5-triton
+  namespace: <your-namespace>
+  labels:
+    trainer.kubeflow.org/framework: torch
+spec:
+  mlPolicy:
+    numNodes: 1
+    torch:
+      numProcPerNode: auto
+  template:
+    spec:
+      replicatedJobs:
+        - name: node
+          template:
+            metadata:
+              labels:
+                trainer.kubeflow.org/trainjob-ancestor-step: trainer
+            spec:
+              backoffLimit: 0
+              template:
+                spec:
+                  securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 1000
+                    runAsGroup: 1000
+                    fsGroup: 1000
+                  volumes:
+                    - name: workspace
+                      emptyDir: {}
+                    - name: dshm
+                      emptyDir:
+                        medium: Memory
+                        sizeLimit: 2Gi
+                  containers:
+                    - name: node
+                      # Replace with the image built in the guide.
+                      image: <your-registry>/yolov5-trainer:v7.0
+                      imagePullPolicy: IfNotPresent
+                      command:
+                        - bash
+                        - -c
+                        - |
+                          set -euo pipefail
+
+                          : "${BASE_MODEL_URL:?Set BASE_MODEL_URL}"
+                          : "${DATASET_URL:?Set DATASET_URL}"
+                          : "${OUTPUT_MODEL_URL:?Set OUTPUT_MODEL_URL}"
+                          : "${OUTPUT_MODEL_BRANCH:?Set OUTPUT_MODEL_BRANCH}"
+                          : "${GIT_USER:?Set GIT_USER}"
+                          : "${GIT_TOKEN:?Set GIT_TOKEN}"
+
+                          WORKSPACE=/workspace
+                          MODEL_DIR="${WORKSPACE}/yolov5"
+                          DATASET_DIR="${WORKSPACE}/datasets/coco128"
+                          TRAIN_DIR="${WORKSPACE}/runs/train"
+                          TRITON_MODEL_DIR="${WORKSPACE}/triton-model"
+                          BASE_MODEL_URL_NO_HTTPS="${BASE_MODEL_URL#https://}"
+                          DATASET_URL_NO_HTTPS="${DATASET_URL#https://}"
+                          OUTPUT_MODEL_URL_NO_HTTPS="${OUTPUT_MODEL_URL#https://}"
+                          OUTPUT_MODEL_NAME="$(basename "${OUTPUT_MODEL_URL%.git}")"
+
+                          # Download the YOLOv5 source, pretrained weight, and dataset from
+                          # the model repositories. Git LFS is required for the images and .pt files.
+                          cat > /tmp/git-askpass <<'EOF'
+                          #!/bin/sh
+                          case "$1" in
+                            *Username*) printf '%s\n' "${GIT_USER}" ;;
+                            *Password*) printf '%s\n' "${GIT_TOKEN}" ;;
+                          esac
+                          EOF
+                          chmod 700 /tmp/git-askpass
+                          export GIT_ASKPASS=/tmp/git-askpass
+                          export GIT_TERMINAL_PROMPT=0
+
+                          GIT_LFS_SKIP_SMUDGE=1 git clone \
+                            "https://${BASE_MODEL_URL_NO_HTTPS}" \
+                            "${MODEL_DIR}"
+                          (cd "${MODEL_DIR}" && git lfs pull)
+
+                          mkdir -p "${WORKSPACE}/datasets"
+                          GIT_LFS_SKIP_SMUDGE=1 git clone \
+                            "https://${DATASET_URL_NO_HTTPS}" \
+                            "${DATASET_DIR}"
+                          (cd "${DATASET_DIR}" && git lfs pull)
+
+                          cd "${MODEL_DIR}"
+                          python train.py \
+                            --img "${IMAGE_SIZE}" \
+                            --batch "${BATCH_SIZE}" \
+                            --epochs "${EPOCHS}" \
+                            --data "${DATASET_YAML}" \
+                            --weights "${BASE_WEIGHTS}" \
+                            --workers "${DATALOADER_WORKERS}" \
+                            --device "${DEVICE}" \
+                            --project "${WORKSPACE}/runs" \
+                            --name train \
+                            --exist-ok
+
+                          test -f "${TRAIN_DIR}/weights/best.pt"
+                          python export.py \
+                            --weights "${TRAIN_DIR}/weights/best.pt" \
+                            --include torchscript \
+                            --device "${DEVICE}"
+                          test -f "${TRAIN_DIR}/weights/best.torchscript"
+
+                          # Triton requires a versioned model directory and config.pbtxt at
+                          # the repository root. This configuration is for the COCO-80,
+                          # 640x640 YOLOv5n example in the guide.
+                          mkdir -p "${TRITON_MODEL_DIR}/1"
+                          cp "${TRAIN_DIR}/weights/best.torchscript" \
+                            "${TRITON_MODEL_DIR}/1/model.pt"
+                          cat > "${TRITON_MODEL_DIR}/config.pbtxt" <<EOF
+                          name: "${OUTPUT_MODEL_NAME}"
+                          platform: "pytorch_libtorch"
+                          max_batch_size: 8
+                          input [
+                            {
+                              name: "images"
+                              data_type: TYPE_FP32
+                              dims: [ 3, 640, 640 ]
+                            }
+                          ]
+                          output [
+                            {
+                              name: "output0"
+                              data_type: TYPE_FP32
+                              dims: [ -1, -1 ]
+                            }
+                          ]
+                          EOF
+                          cat > "${TRITON_MODEL_DIR}/README.md" <<EOF
+                          # YOLOv5 Triton model
+
+                          Fine-tuned from ${BASE_MODEL_URL} using ${DATASET_URL}.
+                          EOF
+
+                          # Publish the model artifact to the output model repository on a new branch.
+                          cd "${TRITON_MODEL_DIR}"
+                          git init
+                          git checkout -b "${OUTPUT_MODEL_BRANCH}"
+                          git lfs track "1/model.pt"
+                          git add .
+                          git -c user.name='AMLSystemUser' \
+                            -c user.email='aml_admin@cpaas.io' \
+                            commit -m 'Publish fine-tuned YOLOv5 Triton model'
+                          git remote add origin "https://${OUTPUT_MODEL_URL_NO_HTTPS}"
+                          git -c http.sslVerify=false -c lfs.activitytimeout=36000 \
+                            push --set-upstream origin "${OUTPUT_MODEL_BRANCH}"
+                          rm -f /tmp/git-askpass
+                      volumeMounts:
+                        - name: workspace
+                          mountPath: /workspace
+                        - name: dshm
+                          mountPath: /dev/shm
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop: [ALL]
+                        runAsNonRoot: true
+                        seccompProfile:
+                          type: RuntimeDefault

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml
@@ -11,30 +11,39 @@ spec:
   trainer:
     numNodes: 1
     env:
-      # HTTPS URLs for the input YOLOv5 repository, dataset repository, and
-      # empty output model repository. GIT_USER and GIT_TOKEN come from the
-      # AML model-repository credential secret.
-      - name: BASE_MODEL_URL
-        value: https://<git-host>/<project>/amlmodels/yolov5
-      - name: DATASET_URL
-        value: https://<git-host>/<project>/amldatasets/coco128
-      - name: OUTPUT_MODEL_URL
-        value: https://<git-host>/<project>/amlmodels/yolov5-coco128-triton
-      - name: OUTPUT_MODEL_BRANCH
-        value: finetune-coco128-v1
-      - name: GIT_USER
+      # S3 URIs for the input YOLOv5 source and weight, dataset, and output
+      # Triton artifact layout. Use a new output prefix for each training run.
+      - name: BASE_MODEL_URI
+        value: s3://<bucket>/yolov5/v7.0
+      - name: DATASET_URI
+        value: s3://<bucket>/datasets/coco128
+      - name: OUTPUT_MODEL_URI
+        value: s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1
+      - name: TRITON_MODEL_NAME
+        value: yolov5-coco128
+      - name: AWS_ACCESS_KEY_ID
         valueFrom:
           secretKeyRef:
-            name: aml-image-builder-secret
-            key: MODEL_REPO_GIT_USER
-      - name: GIT_TOKEN
+            name: yolov5-s3-credentials
+            key: AWS_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
         valueFrom:
           secretKeyRef:
-            name: aml-image-builder-secret
-            key: MODEL_REPO_GIT_TOKEN
+            name: yolov5-s3-credentials
+            key: AWS_SECRET_ACCESS_KEY
+      - name: AWS_S3_ENDPOINT
+        valueFrom:
+          secretKeyRef:
+            name: yolov5-s3-credentials
+            key: AWS_S3_ENDPOINT
+      - name: AWS_DEFAULT_REGION
+        valueFrom:
+          secretKeyRef:
+            name: yolov5-s3-credentials
+            key: AWS_DEFAULT_REGION
 
       # Fine-tuning inputs and hyperparameters. The data/coco128.yaml file in
-      # YOLOv5 expects the data repository at ../datasets/coco128.
+      # YOLOv5 expects the dataset at ../datasets/coco128.
       - name: BASE_WEIGHTS
         value: models/yolov5n.pt
       - name: DATASET_YAML

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml
@@ -1,0 +1,64 @@
+apiVersion: trainer.kubeflow.org/v1alpha1
+kind: TrainJob
+metadata:
+  generateName: yolov5-coco128-
+  namespace: <your-namespace>
+spec:
+  runtimeRef:
+    apiGroup: trainer.kubeflow.org
+    kind: TrainingRuntime
+    name: yolov5-triton
+  trainer:
+    numNodes: 1
+    env:
+      # HTTPS URLs for the input YOLOv5 repository, dataset repository, and
+      # empty output model repository. GIT_USER and GIT_TOKEN come from the
+      # AML model-repository credential secret.
+      - name: BASE_MODEL_URL
+        value: https://<git-host>/<project>/amlmodels/yolov5
+      - name: DATASET_URL
+        value: https://<git-host>/<project>/amldatasets/coco128
+      - name: OUTPUT_MODEL_URL
+        value: https://<git-host>/<project>/amlmodels/yolov5-coco128-triton
+      - name: OUTPUT_MODEL_BRANCH
+        value: finetune-coco128-v1
+      - name: GIT_USER
+        valueFrom:
+          secretKeyRef:
+            name: aml-image-builder-secret
+            key: MODEL_REPO_GIT_USER
+      - name: GIT_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: aml-image-builder-secret
+            key: MODEL_REPO_GIT_TOKEN
+
+      # Fine-tuning inputs and hyperparameters. The data/coco128.yaml file in
+      # YOLOv5 expects the data repository at ../datasets/coco128.
+      - name: BASE_WEIGHTS
+        value: models/yolov5n.pt
+      - name: DATASET_YAML
+        value: data/coco128.yaml
+      - name: IMAGE_SIZE
+        value: "640"
+      - name: BATCH_SIZE
+        value: "16"
+      - name: EPOCHS
+        value: "3"
+      - name: DATALOADER_WORKERS
+        value: "0"
+      - name: DEVICE
+        value: "0"
+    resourcesPerNode:
+      requests:
+        cpu: "1"
+        memory: 8Gi
+        nvidia.com/gpualloc: "1"
+        nvidia.com/gpucores: "50"
+        nvidia.com/gpumem: "8192"
+      limits:
+        cpu: "8"
+        memory: 20Gi
+        nvidia.com/gpualloc: "1"
+        nvidia.com/gpucores: "50"
+        nvidia.com/gpumem: "8192"

--- a/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py
+++ b/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py
@@ -21,8 +21,8 @@ def model():
         raise RuntimeError("No Ascend NPU is available to torch_npu")
     if not os.path.isfile(MODEL_PATH):
         raise RuntimeError(f"TorchScript model not found: {MODEL_PATH}")
-    loaded = torch.jit.load(MODEL_PATH, map_location="cpu")
-    loaded.to(DEVICE).eval()
+    loaded = torch.jit.load(MODEL_PATH, map_location=DEVICE)
+    loaded.eval()
     return loaded
 
 

--- a/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py
+++ b/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py
@@ -10,6 +10,8 @@ from fastapi import FastAPI, HTTPException
 MODEL_NAME = os.environ.get("MODEL_NAME", "yolov5-coco128")
 MODEL_PATH = os.environ.get("MODEL_PATH", "/mnt/models/1/model.pt")
 DEVICE = os.environ.get("NPU_DEVICE", "npu:0")
+MAX_BATCH_SIZE = int(os.environ.get("MAX_BATCH_SIZE", "8"))
+INPUT_SHAPE = (3, 640, 640)
 app = FastAPI()
 
 
@@ -53,12 +55,28 @@ def infer(model_name: str, request: dict):
 
     shape = image.get("shape")
     data = image.get("data")
-    if not isinstance(shape, list) or data is None:
+    if not isinstance(shape, list) or not isinstance(data, list):
         raise HTTPException(status_code=400, detail="images must include shape and data")
 
-    values = np.asarray(data, dtype=np.float32)
-    if values.size != int(np.prod(shape)):
+    if (
+        len(shape) != 4
+        or any(not isinstance(dimension, int) or isinstance(dimension, bool) for dimension in shape)
+        or not 1 <= shape[0] <= MAX_BATCH_SIZE
+        or tuple(shape[1:]) != INPUT_SHAPE
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"images must have shape [batch, 3, 640, 640] with batch between 1 and {MAX_BATCH_SIZE}",
+        )
+
+    expected_values = int(np.prod(shape))
+    if len(data) != expected_values:
         raise HTTPException(status_code=400, detail="images data does not match shape")
+
+    try:
+        values = np.asarray(data, dtype=np.float32)
+    except (TypeError, ValueError) as error:
+        raise HTTPException(status_code=400, detail="images data must contain FP32 values") from error
 
     tensor = torch.from_numpy(values.reshape(shape)).to(DEVICE)
     with torch.inference_mode():

--- a/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py
+++ b/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py
@@ -1,0 +1,81 @@
+import os
+from functools import lru_cache
+
+import numpy as np
+import torch
+import torch_npu  # Registers the "npu" device with PyTorch.
+from fastapi import FastAPI, HTTPException
+
+
+MODEL_NAME = os.environ.get("MODEL_NAME", "yolov5-coco128")
+MODEL_PATH = os.environ.get("MODEL_PATH", "/mnt/models/1/model.pt")
+DEVICE = os.environ.get("NPU_DEVICE", "npu:0")
+app = FastAPI()
+
+
+@lru_cache(maxsize=1)
+def model():
+    if not torch_npu.npu.is_available():
+        raise RuntimeError("No Ascend NPU is available to torch_npu")
+    if not os.path.isfile(MODEL_PATH):
+        raise RuntimeError(f"TorchScript model not found: {MODEL_PATH}")
+    loaded = torch.jit.load(MODEL_PATH, map_location="cpu")
+    loaded.to(DEVICE).eval()
+    return loaded
+
+
+@app.on_event("startup")
+def load_model():
+    model()
+
+
+@app.get("/v2/health/live")
+@app.get("/v2/health/ready")
+@app.get("/v2/models/{model_name}/ready")
+def ready(model_name: str | None = None):
+    if model_name is not None and model_name != MODEL_NAME:
+        raise HTTPException(status_code=404, detail="Unknown model")
+    model()
+    return {}
+
+
+@app.post("/v2/models/{model_name}/infer")
+def infer(model_name: str, request: dict):
+    if model_name != MODEL_NAME:
+        raise HTTPException(status_code=404, detail="Unknown model")
+
+    inputs = request.get("inputs", [])
+    image = next((item for item in inputs if item.get("name") == "images"), None)
+    if image is None:
+        raise HTTPException(status_code=400, detail="Missing FP32 input named images")
+    if image.get("datatype") != "FP32":
+        raise HTTPException(status_code=400, detail="images must use FP32 data")
+
+    shape = image.get("shape")
+    data = image.get("data")
+    if not isinstance(shape, list) or data is None:
+        raise HTTPException(status_code=400, detail="images must include shape and data")
+
+    values = np.asarray(data, dtype=np.float32)
+    if values.size != int(np.prod(shape)):
+        raise HTTPException(status_code=400, detail="images data does not match shape")
+
+    tensor = torch.from_numpy(values.reshape(shape)).to(DEVICE)
+    with torch.inference_mode():
+        output = model()(tensor)
+    if isinstance(output, (tuple, list)):
+        output = output[0]
+    output = output.detach().float().cpu().numpy()
+
+    return {
+        "model_name": MODEL_NAME,
+        "model_version": "1",
+        "outputs": [
+            {
+                "name": "output0",
+                "datatype": "FP32",
+                "shape": list(output.shape),
+                "data": output.flatten().tolist(),
+            }
+        ],
+    }

--- a/docs/en/train/guides/index.mdx
+++ b/docs/en/train/guides/index.mdx
@@ -4,12 +4,13 @@ weight: 10
 
 # Training Guides
 
-End-to-end recipes for fine-tuning and pretraining LLMs on Alauda AI.
+End-to-end recipes for training and fine-tuning models on Alauda AI.
 
 ## Pick a path
 
 | When you want… | Use | Guide |
 |---|---|---|
+| Fine-tune a YOLOv5 object-detection model and deploy it with Triton | Kubeflow Trainer v2 + Triton Inference Server | [Train, Fine-Tune, and Deploy YOLOv5](./yolov5-training-and-triton-deployment.mdx) |
 | Reusable templates, repeatable runs, optional Kueue quotas | Kubeflow Trainer v2 + LlamaFactory | [Fine-Tuning with Kubeflow Trainer v2](./fine-tune-with-trainer-v2.mdx) |
 | Survive crashes, preemption, or a pause without losing hours of training | Checkpoint PVC + `resume_from_checkpoint` + `maxRestarts` | [Checkpointing and Resuming TrainJobs](./checkpointing-and-resuming.mdx) |
 | Mix training with online inference, yield GPU back on demand | Kueue cohort + preemption + checkpoint resume | [Preemptible TrainJobs with Kueue](./preemptible-trainjobs-with-kueue.mdx) |

--- a/docs/en/train/guides/index.mdx
+++ b/docs/en/train/guides/index.mdx
@@ -10,6 +10,7 @@ End-to-end recipes for training and fine-tuning models on Alauda AI.
 
 | When you want… | Use | Guide |
 |---|---|---|
+| Fine-tune or train on GPU and serve a compatible model on Ascend NPU | Cross-accelerator workflow index | [Train on GPU and Run Inference on NPU](./train-on-gpu-infer-on-npu.mdx) |
 | Fine-tune a YOLOv5 object-detection model and deploy it with Triton | Kubeflow Trainer v2 + Triton Inference Server | [Train, Fine-Tune, and Deploy YOLOv5](./yolov5-training-and-triton-deployment.mdx) |
 | Reusable templates, repeatable runs, optional Kueue quotas | Kubeflow Trainer v2 + LlamaFactory | [Fine-Tuning with Kubeflow Trainer v2](./fine-tune-with-trainer-v2.mdx) |
 | Survive crashes, preemption, or a pause without losing hours of training | Checkpoint PVC + `resume_from_checkpoint` + `maxRestarts` | [Checkpointing and Resuming TrainJobs](./checkpointing-and-resuming.mdx) |

--- a/docs/en/train/guides/train-on-gpu-infer-on-npu.mdx
+++ b/docs/en/train/guides/train-on-gpu-infer-on-npu.mdx
@@ -6,6 +6,21 @@ weight: 20
 
 Training and inference can use different accelerator types. This page is an index for workflows that fine-tune or train a model on NVIDIA GPUs and serve a compatible exported model on Huawei Ascend NPUs. It does not replace the linked guides or provide deployment steps.
 
+## Supported model artifacts for NPU inference
+
+The selected NPU runtime determines which artifacts it can load. The following are the model representations covered by the referenced NPU-serving guides; they are not a universal compatibility matrix for every Ascend device, model architecture, or runtime version.
+
+| Workload | Model artifact or representation | NPU serving path and compatibility notes |
+| --- | --- | --- |
+| LLM | A Hugging Face model directory with configuration and tokenizer files plus FP16 or BF16 `.safetensors` weights | Serve it with a compatible `vLLM-ascend` runtime using the `transformers` model format. The model architecture, selected runtime image, and CANN stack must support the model and precision. |
+| LLM | W8A8-quantized model package | Serve it only with a compatible vLLM-Ascend/model combination and its required quantization configuration. For a validated W8A8 example, see [Qwen3.6-27B (W8A8)](../../plan/validated_models/qwen3-6-27b-w8a8.mdx). |
+| LLM | A single-file GGUF model | The documented `vLLM-ascend` runtime can detect a single `.gguf` file. Multi-file GGUF packages are not supported by that loader. |
+| Machine learning | TorchScript `.pt` model | The YOLOv5 sample loads the exported model with `torch_npu`. The model must be compatible with the PyTorch and CANN versions in the serving image. |
+| Machine learning | ONNX `.onnx` model | The YOLOv5 native CANN path uses ONNX as the input to ATC conversion; it is not the deployed executable in that path. |
+| Machine learning | CANN offline `.om` model | Deploy it through an AscendCL-based service after compiling it for the destination Ascend SKU and compatible CANN/driver stack. |
+
+`transformers` in an `InferenceService` or `ClusterServingRuntime` identifies the model-directory format expected by the runtime. It does not by itself state that every precision or quantization method is supported. Validate the exact model, weight representation, serving image, CANN version, driver, and NPU SKU before deployment.
+
 ## Fine-tune LLMs on GPU and run LLM inference on NPU
 
 Use one of these guides to fine-tune an LLM on GPU:

--- a/docs/en/train/guides/train-on-gpu-infer-on-npu.mdx
+++ b/docs/en/train/guides/train-on-gpu-infer-on-npu.mdx
@@ -1,0 +1,28 @@
+---
+weight: 20
+---
+
+# Train on GPU and Run Inference on NPU
+
+Training and inference can use different accelerator types. This page is an index for workflows that fine-tune or train a model on NVIDIA GPUs and serve a compatible exported model on Huawei Ascend NPUs. It does not replace the linked guides or provide deployment steps.
+
+## Fine-tune LLMs on GPU and run LLM inference on NPU
+
+Use one of these guides to fine-tune an LLM on GPU:
+
+- [Fine-Tuning with Kubeflow Trainer v2](./fine-tune-with-trainer-v2.mdx) for a reusable `TrainingRuntime` and `TrainJob` workflow.
+- [Fine-tuning LLMs with Training Hub](./training-hub-fine-tuning.mdx) for SFT, OSFT, LoRA, QLoRA, and continued pre-training workflows.
+- [Training Runtime Images](./training-runtimes.mdx) to select a CUDA training runtime.
+
+After the fine-tuned model is published to the model storage location used by your platform, use the NPU-serving guidance in [Extend Inference Runtimes](../../deploy/inference_service/guides/custom_inference_runtime.mdx). Its `vLLM-ascend` section covers Ascend NPU runtime and `InferenceService` configuration. For platform-wide service lifecycle and operations, see [Managing Inference Services](../../deploy/inference_service/inference_service.mdx).
+
+Verify that the exported model, selected NPU serving engine, CANN stack, tokenizer, and model-storage format are compatible before moving a GPU-trained model to an NPU serving environment.
+
+## Train machine-learning models on GPU and run inference on NPU
+
+For an end-to-end object-detection example, use [Train, Fine-Tune, and Deploy YOLOv5](./yolov5-training-and-triton-deployment.mdx). It covers GPU training with Kubeflow Trainer v2 and two Ascend NPU inference choices:
+
+- A custom KServe runtime that serves the exported TorchScript model with `torch_npu`.
+- A native CANN path that converts a YOLOv5 ONNX model to an `.om` model with ATC and executes it through AscendCL.
+
+The YOLOv5 guide also documents the validated CANN compiler image and NPU environment. Use it as the reference for artifact conversion, model storage, and NPU runtime compatibility for similar machine-learning models.

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -1,0 +1,191 @@
+---
+weight: 25
+---
+
+# Train, Fine-Tune, and Deploy YOLOv5 with Kubeflow Trainer v2
+
+Fine-tune a YOLOv5 object-detection model on Alauda AI, package the trained model for Triton Inference Server, and publish it as an online inference service. This guide uses **Kubeflow Trainer v2** (`TrainingRuntime` and `TrainJob`), not `VolcanoJob`.
+
+The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDIA GPU. It runs all preparation, training, export, and publishing actions in the Trainer v2 `node` step, so it does not require a shared workspace PVC.
+
+## Prerequisites
+
+| Requirement | Details |
+| --- | --- |
+| Alauda AI | 1.3 or later, with Kubeflow Trainer v2 installed |
+| Hardware | x86_64 worker node with an NVIDIA GPU. NPU support requires a compatible YOLOv5 training and serving image. |
+| Access | `kubectl` permission to create `trainingruntimes` and `trainjobs` in your project namespace |
+| Model repositories | Three Git LFS-enabled repositories: a YOLOv5 base model, a dataset, and an empty output-model repository |
+| Git credentials | The `aml-image-builder-secret` secret, containing `MODEL_REPO_GIT_USER` and `MODEL_REPO_GIT_TOKEN` |
+| Image registry | A registry reachable by the training nodes, to host the custom YOLOv5 training image |
+
+The sample resources use Alauda AI's NVIDIA vGPU resource keys (`nvidia.com/gpualloc`, `nvidia.com/gpucores`, and `nvidia.com/gpumem`). If your cluster allocates whole GPUs, replace all three keys with `nvidia.com/gpu: 1` in the `TrainJob`.
+
+## Prepare the model and dataset repositories
+
+Create the following repositories in **Model Repository**. The training pod clones each repository through its HTTPS Git URL, so the credentials secret must be able to read the first two and write the output repository.
+
+| Repository | Contents |
+| --- | --- |
+| Base model | The [YOLOv5 v7.0](https://github.com/ultralytics/yolov5/tree/v7.0) source tree, including `models/yolov5n.pt` tracked with Git LFS |
+| Dataset | The extracted [COCO128](https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip) directory. Its top level must contain `images/` and `labels/`. Track `*.jpg` with Git LFS. |
+| Output model | An empty model repository to receive the Triton model repository created by the training job |
+
+YOLOv5 ignores `*.pt` by default, so remove that entry from the source tree's `.gitignore` before adding `models/yolov5n.pt`. `data/coco128.yaml` expects the dataset at `../datasets/coco128` relative to the YOLOv5 source tree. The supplied runtime clones the dataset to exactly that path. For a custom dataset, use a data YAML file in the base-model repository whose `path` matches the directory used by the runtime, or update the runtime and `DATASET_YAML` together.
+
+See [Model Repository](../../deploy/model_management/model_repository.mdx) for Git LFS model-repository usage.
+
+## Build the training image
+
+Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image first if your cluster cannot pull it directly. The image adds Git, Git LFS, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots.
+
+```dockerfile
+FROM nvcr.io/nvidia/pytorch:24.12-py3
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      curl ffmpeg git git-lfs libfreetype6-dev libgl1 libglib2.0-0 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL \
+      https://raw.githubusercontent.com/ultralytics/yolov5/v7.0/requirements.txt \
+      -o /tmp/requirements.txt && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
+    pip install --no-cache-dir Pillow==10.4.0 && \
+    rm /tmp/requirements.txt
+
+RUN mkdir -p /opt/Ultralytics && \
+    curl -fsSL https://ultralytics.com/assets/Arial.ttf \
+      -o /opt/Ultralytics/Arial.ttf && \
+    curl -fsSL https://ultralytics.com/assets/Arial.Unicode.ttf \
+      -o /opt/Ultralytics/Arial.Unicode.ttf
+
+RUN groupadd --gid 1000 appuser && \
+    useradd --uid 1000 --gid 1000 --create-home appuser && \
+    mkdir -p /workspace /home/appuser/.config/Ultralytics && \
+    cp /opt/Ultralytics/* /home/appuser/.config/Ultralytics/ && \
+    chown -R 1000:1000 /workspace /home/appuser
+
+USER 1000
+WORKDIR /workspace
+```
+
+For example:
+
+```bash
+docker build -f Containerfile -t <your-registry>/yolov5-trainer:v7.0 .
+docker push <your-registry>/yolov5-trainer:v7.0
+```
+
+## Create the Trainer v2 runtime
+
+Download [`yolov5-triton-trainingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml), then make these changes before applying it:
+
+1. Replace `<your-namespace>` with the target project namespace.
+2. Replace `<your-registry>/yolov5-trainer:v7.0` with the image you pushed.
+
+Apply the runtime:
+
+```bash
+kubectl apply -f yolov5-triton-trainingruntime.yaml
+kubectl get trainingruntime yolov5-triton -n <your-namespace>
+```
+
+The runtime is reusable. It validates the required input variables, clones the model and data with Git LFS, runs `train.py`, exports `best.pt` as TorchScript, and pushes the following artifact layout to the output repository:
+
+```text
+.
+├── 1/
+│   └── model.pt
+├── config.pbtxt
+└── README.md
+```
+
+This is the layout expected by Triton. `config.pbtxt` is configured for the example's 640 × 640 COCO model. If you change the input image size or the model output signature, update the config in the runtime before training. Confirm the input and output names and shapes with the exported model before publishing a custom model.
+
+## Submit a YOLOv5 fine-tuning job
+
+Download [`yolov5-triton-trainjob.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml). Edit the namespace, the three Git URLs, and `OUTPUT_MODEL_BRANCH`; the output branch must be new or unused. Then set the resource limits and the training values that fit your cluster:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `BASE_WEIGHTS` | `models/yolov5n.pt` | Pretrained model relative to the base-model repository |
+| `DATASET_YAML` | `data/coco128.yaml` | YOLOv5 dataset configuration relative to the base-model repository |
+| `IMAGE_SIZE` | `640` | Input image width and height |
+| `BATCH_SIZE` | `16` | Per-device batch size; lower it if the GPU runs out of memory |
+| `EPOCHS` | `3` | Number of fine-tuning epochs |
+| `DATALOADER_WORKERS` | `0` | Data-loader workers; raise only after confirming the shared-memory allocation is sufficient |
+| `DEVICE` | `0` | GPU index; set `cpu` for CPU-only testing and remove GPU resource requests |
+
+Create and watch the job:
+
+```bash
+kubectl create -f yolov5-triton-trainjob.yaml
+kubectl get trainjobs -n <your-namespace> --watch
+kubectl get pods -n <your-namespace>
+kubectl logs -n <your-namespace> <trainer-pod-name> -c node -f
+```
+
+When the `TrainJob` succeeds, the output model repository contains the `OUTPUT_MODEL_BRANCH` created by the job. The log includes failures from cloning, training, TorchScript export, or the Git push; no `VolcanoJob`, `vcjob`, or `PodGroup` is created.
+
+:::tip
+The supplied manifest is intentionally a one-node recipe. Increasing `trainer.numNodes` alone does not make YOLOv5 distributed: the runtime command must also launch a distributed training process (for example, with `torchrun`) and the data path must be reachable by every node.
+:::
+
+## Register the Triton runtime
+
+If the cluster does not already provide a compatible Triton runtime, a cluster administrator can apply [`triton-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml):
+
+```bash
+kubectl apply -f triton-servingruntime.yaml
+```
+
+The sample uses `alaudadockerhub/tritonserver:25.02-py3`, CUDA 12.1, and the `triton` model format. Change the image and accelerator labels to match the image and hardware available in your cluster. For a fuller explanation of custom serving runtimes, see [Extend Inference Runtimes](../../deploy/inference_service/guides/custom_inference_runtime.mdx).
+
+## Publish and call the inference service
+
+1. In **Model Repository**, open the output model repository and select the `OUTPUT_MODEL_BRANCH` created by the job.
+2. In **File Management**, select **Edit Metadata**. Set **Task Type** to **Object Detection** and **Framework** to **triton**. The framework must match `supportedModelFormats` in the `ClusterServingRuntime`.
+3. Select **Publish Inference Service**. Choose the Triton runtime, configure CPU, memory, GPU, and model-cache storage, then publish.
+4. Wait for the service to be running. The **Access Method** tab provides its in-cluster URL.
+
+:::note
+Model Repository reads deployment metadata from the default branch. If the **Publish Inference Service** button is unavailable while `OUTPUT_MODEL_BRANCH` is selected, set the metadata on the repository's default branch, then publish the output branch as the model version.
+:::
+
+Triton serves the HTTP v2 API. From a workbench or other pod in the cluster, use this minimal client to send a normalized 640 × 640 RGB image:
+
+```python
+import numpy as np
+import requests
+from PIL import Image
+
+service_url = "http://<in-cluster-service-url>"
+image = Image.open("image.jpg").convert("RGB").resize((640, 640))
+tensor = np.asarray(image, dtype=np.float32).transpose(2, 0, 1) / 255.0
+tensor = np.expand_dims(tensor, axis=0)
+
+payload = {
+    "inputs": [{
+        "name": "images",
+        "shape": list(tensor.shape),
+        "datatype": "FP32",
+        "data": tensor.flatten().tolist(),
+    }],
+    "outputs": [{"name": "output0"}],
+}
+response = requests.post(
+    f"{service_url}/v2/models/<output-model-repository-name>/infer",
+    json=payload,
+    timeout=60,
+)
+response.raise_for_status()
+output = response.json()["outputs"][0]
+predictions = np.asarray(output["data"]).reshape(output["shape"])
+print(predictions.shape)
+```
+
+The raw output contains candidate boxes and class scores. YOLOv5 post-processing—confidence filtering, non-maximum suppression, scaling boxes back to the original image, and drawing labels—runs in the client application and is deliberately outside this deployment recipe.
+
+For the general model-service workflow and troubleshooting, see [Managing Inference Services](../../deploy/inference_service/inference_service.mdx).

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -4,7 +4,7 @@ weight: 25
 
 # Train, Fine-Tune, and Deploy YOLOv5 with Kubeflow Trainer v2
 
-Fine-tune a YOLOv5 object-detection model on Alauda AI, package the trained model for Triton Inference Server, and publish it as an online inference service. The base model, dataset, and output model are stored in S3-compatible object storage. This guide uses **Kubeflow Trainer v2** (`TrainingRuntime` and `TrainJob`), not `VolcanoJob`.
+Fine-tune a YOLOv5 object-detection model on Alauda AI, package the trained model for Triton Inference Server, and publish it as an online inference service. The base model, dataset, and output model are stored in S3-compatible object storage. This guide uses **Kubeflow Trainer v2** resources: `TrainingRuntime` and `TrainJob`.
 
 The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDIA GPU. It runs all preparation, training, export, and publishing actions in the Trainer v2 `node` step, so it does not require a shared workspace PVC.
 
@@ -14,10 +14,10 @@ The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDI
 | --- | --- |
 | Alauda AI | 1.3 or later, with Kubeflow Trainer v2 installed |
 | Hardware | x86_64 worker node with an NVIDIA GPU for the default Triton path. See [Deploy on Ascend NPU](#deploy-on-ascend-npu) for the separate arm64 NPU serving path. |
-| Access | `kubectl` permission to create `trainingruntimes` and `trainjobs` in your project namespace |
+| Access | Least-privilege `kubectl` permission to create `trainingruntimes` and `trainjobs` in your project namespace; cluster-administrator access only when creating a `ClusterServingRuntime` |
 | S3-compatible storage | A bucket with read access to the base-model and dataset prefixes and read/write access to the output-model prefix |
-| S3 credentials | The `yolov5-s3-credentials` Secret, with access key, secret key, endpoint, and region. It is also attached to the inference ServiceAccount. |
-| Image registry | A registry reachable by the training nodes, to host the custom YOLOv5 training image |
+| S3 credentials | The `yolov5-s3-credentials` Secret, with an access key, secret key, endpoint, and region. Grant it only the required source reads and output writes. It is also attached to the inference ServiceAccount. |
+| Image registry | An approved registry reachable by the training and serving nodes, to host pinned YOLOv5 and Triton images |
 
 The sample resources use Alauda AI's NVIDIA vGPU resource keys (`nvidia.com/gpualloc`, `nvidia.com/gpucores`, and `nvidia.com/gpumem`). If your cluster allocates whole GPUs, replace all three keys with `nvidia.com/gpu: 1` in the `TrainJob`.
 
@@ -40,6 +40,10 @@ aws --endpoint-url "$AWS_S3_ENDPOINT" s3 sync ./coco128/ s3://<bucket>/datasets/
 
 `data/coco128.yaml` expects the dataset at `../datasets/coco128` relative to the YOLOv5 source tree. The supplied runtime downloads the dataset to exactly that path. For a custom dataset, use a data YAML file in the base-model prefix whose `path` matches the directory used by the runtime, or update the runtime and `DATASET_YAML` together.
 
+:::caution
+The base-model prefix contains Python code that the training pod executes. Populate it only from a reviewed, version-pinned YOLOv5 source tree, and restrict write access to that prefix. Do not grant an untrusted uploader the ability to replace the source tree or pretrained weight.
+:::
+
 ## Create S3 credentials and inference ServiceAccount \{#create-s3-credentials-and-inference-serviceaccount}
 
 Download [`s3-model-storage.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml). Set the namespace, endpoint, protocol, region, access key, and secret key, then apply it:
@@ -50,12 +54,17 @@ kubectl apply -f s3-model-storage.yaml
 
 The Secret's `AWS_S3_ENDPOINT` value includes `http://` or `https://` for the AWS CLI. The `serving.kserve.io/s3-endpoint` annotation must omit the scheme because KServe reads its protocol from `serving.kserve.io/s3-usehttps`. This Secret is referenced directly by the `TrainJob` and indirectly by the `InferenceService` through the `yolov5-s3` ServiceAccount.
 
+:::caution
+Do not commit populated Secret manifests. Use your managed-secret workflow or an ignored local copy, and rotate the credentials after an incident. Scope the credential to read only the base-model and dataset prefixes and to write only the unique output-model prefix. Keep `s3-usehttps: "1"` for production; use HTTP only for a private test endpoint after accepting the transport risk.
+:::
+
 ## Build the training image
 
-Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image first if your cluster cannot pull it directly. The image adds the AWS CLI, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots.
+Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image to an approved internal registry and pin it by digest before a production build. The required `BASE_IMAGE` argument makes that choice explicit. The image adds the AWS CLI, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots. For production, review or mirror the downloaded Python dependencies through your approved package source.
 
-```dockerfile
-FROM nvcr.io/nvidia/pytorch:24.12-py3
+```containerfile
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -89,8 +98,11 @@ WORKDIR /workspace
 For example:
 
 ```bash
-docker build -f Containerfile -t <your-registry>/yolov5-trainer:v7.0 .
-docker push <your-registry>/yolov5-trainer:v7.0
+nerdctl build \
+  --build-arg BASE_IMAGE=<your-registry>/nvidia-pytorch:24.12-py3@sha256:<digest> \
+  -f Containerfile \
+  -t <your-registry>/yolov5-trainer:v7.0 .
+nerdctl push <your-registry>/yolov5-trainer:v7.0
 ```
 
 ## Create the Trainer v2 runtime
@@ -98,7 +110,7 @@ docker push <your-registry>/yolov5-trainer:v7.0
 Download [`yolov5-triton-trainingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml), then make these changes before applying it:
 
 1. Replace `<your-namespace>` with the target project namespace.
-2. Replace `<your-registry>/yolov5-trainer:v7.0` with the image you pushed.
+2. Replace `<your-registry>/yolov5-trainer:v7.0` with the image you pushed. For production, use an immutable digest instead of a mutable tag.
 
 Apply the runtime:
 
@@ -142,7 +154,7 @@ kubectl get pods -n <your-namespace>
 kubectl logs -n <your-namespace> <trainer-pod-name> -c node -f
 ```
 
-When the `TrainJob` succeeds, `OUTPUT_MODEL_URI` contains the deployable Triton artifact. The log includes failures from S3 download, training, TorchScript export, or S3 upload; no `VolcanoJob`, `vcjob`, or `PodGroup` is created.
+When the `TrainJob` succeeds, `OUTPUT_MODEL_URI` contains the deployable Triton artifact. Its log reports failures from S3 download, training, TorchScript export, or S3 upload.
 
 :::tip
 The supplied manifest is intentionally a one-node recipe. Increasing `trainer.numNodes` alone does not make YOLOv5 distributed: the runtime command must also launch a distributed training process (for example, with `torchrun`) and the data path must be reachable by every node.
@@ -150,13 +162,13 @@ The supplied manifest is intentionally a one-node recipe. Increasing `trainer.nu
 
 ## Register the Triton runtime
 
-If the cluster does not already provide a compatible Triton runtime, a cluster administrator can apply [`triton-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml):
+If the cluster does not already provide a compatible Triton runtime, a cluster administrator can apply [`triton-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml). Before applying it, replace its image with an approved internal mirror pinned by digest:
 
 ```bash
 kubectl apply -f triton-servingruntime.yaml
 ```
 
-The sample uses `alaudadockerhub/tritonserver:25.02-py3`, CUDA 12.1, and the `triton` model format. Change the image and accelerator labels to match the image and hardware available in your cluster. For a fuller explanation of custom serving runtimes, see [Extend Inference Runtimes](../../deploy/inference_service/guides/custom_inference_runtime.mdx).
+The sample targets Triton 25.02, CUDA 12.1, and the `triton` model format. Change the image and accelerator labels to match the image and hardware available in your cluster. Ensure serving nodes can pull the selected image before deploying; an internal mirror avoids a runtime dependency on a public registry. For a fuller explanation of custom serving runtimes, see [Extend Inference Runtimes](../../deploy/inference_service/guides/custom_inference_runtime.mdx).
 
 ## Deploy and call the inference service
 
@@ -224,12 +236,14 @@ The training job already uploads `1/model.pt` under `OUTPUT_MODEL_URI`. The NPU 
 
 ### Build the Ascend serving image
 
-Download [`yolov5-ascend.Containerfile`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile) and [`yolov5_ascend_server.py`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py) into the same directory. The image extends the CANN PyTorch runtime and exposes the KServe v2 health and inference endpoints for `images` and `output0`.
+Download [`yolov5-ascend.Containerfile`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile) and [`yolov5_ascend_server.py`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py) into the same directory. The image extends the CANN PyTorch runtime and exposes the KServe v2 health and inference endpoints for `images` and `output0`. Supply an approved, digest-pinned internal CANN base image when you build it.
 
 ```bash
-docker build -f yolov5-ascend.Containerfile \
+nerdctl build \
+  --build-arg BASE_IMAGE=<your-registry>/torch2.6-cann8.5-arm64:v0.1.0@sha256:<digest> \
+  -f yolov5-ascend.Containerfile \
   -t <your-registry>/yolov5-ascend:cann8.5 .
-docker push <your-registry>/yolov5-ascend:cann8.5
+nerdctl push <your-registry>/yolov5-ascend:cann8.5
 ```
 
 ### Register the Ascend serving runtime

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -13,7 +13,7 @@ The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDI
 | Requirement | Details |
 | --- | --- |
 | Alauda AI | 1.3 or later, with Kubeflow Trainer v2 installed |
-| Hardware | x86_64 worker node with an NVIDIA GPU. NPU support requires a compatible YOLOv5 training and serving image. |
+| Hardware | x86_64 worker node with an NVIDIA GPU for the default Triton path. See [Deploy on Ascend NPU](#deploy-on-ascend-npu) for the separate arm64 NPU serving path. |
 | Access | `kubectl` permission to create `trainingruntimes` and `trainjobs` in your project namespace |
 | S3-compatible storage | A bucket with read access to the base-model and dataset prefixes and read/write access to the output-model prefix |
 | S3 credentials | The `yolov5-s3-credentials` Secret, with access key, secret key, endpoint, and region. It is also attached to the inference ServiceAccount. |
@@ -40,7 +40,7 @@ aws --endpoint-url "$AWS_S3_ENDPOINT" s3 sync ./coco128/ s3://<bucket>/datasets/
 
 `data/coco128.yaml` expects the dataset at `../datasets/coco128` relative to the YOLOv5 source tree. The supplied runtime downloads the dataset to exactly that path. For a custom dataset, use a data YAML file in the base-model prefix whose `path` matches the directory used by the runtime, or update the runtime and `DATASET_YAML` together.
 
-## Create S3 credentials and inference ServiceAccount
+## Create S3 credentials and inference ServiceAccount \{#create-s3-credentials-and-inference-serviceaccount}
 
 Download [`s3-model-storage.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml). Set the namespace, endpoint, protocol, region, access key, and secret key, then apply it:
 
@@ -208,5 +208,59 @@ print(predictions.shape)
 ```
 
 The raw output contains candidate boxes and class scores. YOLOv5 post-processing—confidence filtering, non-maximum suppression, scaling boxes back to the original image, and drawing labels—runs in the client application and is deliberately outside this deployment recipe.
+
+## Deploy on Ascend NPU \{#deploy-on-ascend-npu}
+
+The Triton runtime above is for NVIDIA CUDA and cannot serve an Ascend NPU. To deploy the same S3-stored model on a Huawei Ascend NPU, use a custom KServe runtime that loads the exported TorchScript model with `torch_npu`. This section targets arm64 Ascend 910B4 nodes with CANN 8.5; adjust the image, CANN version, and resource keys for other Ascend hardware.
+
+The training job already uploads `1/model.pt` under `OUTPUT_MODEL_URI`. The NPU runtime consumes that file directly; it does not use Triton's `config.pbtxt`.
+
+### Prerequisites
+
+- Ascend driver, Kubernetes device plugin, and the platform's Ascend serving configuration are installed on the target nodes.
+- The `yolov5-s3` ServiceAccount and S3 credentials from [Create S3 credentials and inference ServiceAccount](#create-s3-credentials-and-inference-serviceaccount) exist in the deployment namespace.
+- The CANN image can access the host CANN libraries. Its entrypoint must source `/usr/local/Ascend/ascend-toolkit/set_env.sh` before importing `torch_npu`.
+- The exported TorchScript model is compatible with the PyTorch/CANN version in the serving image. Re-export it with the matching stack if loading fails.
+
+### Build the Ascend serving image
+
+Download [`yolov5-ascend.Containerfile`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile) and [`yolov5_ascend_server.py`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py) into the same directory. The image extends the CANN PyTorch runtime and exposes the KServe v2 health and inference endpoints for `images` and `output0`.
+
+```bash
+docker build -f yolov5-ascend.Containerfile \
+  -t <your-registry>/yolov5-ascend:cann8.5 .
+docker push <your-registry>/yolov5-ascend:cann8.5
+```
+
+### Register the Ascend serving runtime
+
+Download [`yolov5-ascend-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml), replace its image with the one you built, and apply it as a cluster administrator:
+
+```bash
+kubectl apply -f yolov5-ascend-servingruntime.yaml
+```
+
+### Create the Ascend inference service
+
+Download [`yolov5-ascend-inferenceservice.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend-inferenceservice.yaml). Set the namespace and `storageUri` to the `OUTPUT_MODEL_URI` written by the `TrainJob`. Keep `aml-model-repo` equal to `TRITON_MODEL_NAME`, because the custom runtime uses that value as its KServe v2 model name.
+
+The sample requests one HAMI vNPU slice:
+
+```yaml
+limits:
+  huawei.com/Ascend910B4: "1"
+  huawei.com/Ascend910B4-memory: "8192"
+```
+
+For the standard Huawei device plugin, replace those two keys with `huawei.com/Ascend910: "1"`. Follow the cluster's Ascend scheduling convention, including the required RuntimeClass or HAMI scheduler configuration. See [Training Runtime Images](./training-runtimes.mdx) for the resource-key details.
+
+Apply and wait for the service:
+
+```bash
+kubectl apply -f yolov5-ascend-inferenceservice.yaml
+kubectl get inferenceservice yolov5-coco128-ascend -n <your-namespace> --watch
+```
+
+The Ascend service uses the same KServe v2 request body as the Triton example; only its service URL changes. Validate the service with a sample image before putting it behind production traffic, because operator coverage and TorchScript compatibility depend on the selected CANN/PyTorch stack.
 
 For the general model-service workflow and troubleshooting, see [Managing Inference Services](../../deploy/inference_service/inference_service.mdx).

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -223,18 +223,26 @@ The raw output contains candidate boxes and class scores. YOLOv5 post-processing
 
 ## Deploy on Ascend NPU \{#deploy-on-ascend-npu}
 
-The Triton runtime above is for NVIDIA CUDA and cannot serve an Ascend NPU. To deploy the same S3-stored model on a Huawei Ascend NPU, use a custom KServe runtime that loads the exported TorchScript model with `torch_npu`. This section targets arm64 Ascend 910B4 nodes with CANN 8.5; adjust the image, CANN version, and resource keys for other Ascend hardware.
+The Triton runtime above is for NVIDIA CUDA and cannot serve an Ascend NPU. This guide provides a runnable custom KServe runtime that loads the exported TorchScript model with `torch_npu`. It targets arm64 Ascend 910B4 nodes with CANN 8.5; adjust the image, CANN version, and resource keys for other Ascend hardware.
+
+For a native CANN production implementation, use Ascend's [CANN YOLO model-inference sample](https://github.com/Ascend/samples/tree/master/inference/modelInference/sampleYOLOV7) as the reference architecture. The published sample uses YOLOv7, but its deployment flow is applicable to a compatible YOLOv5 export: export the model to ONNX, compile it with CANN ATC to an `.om` offline model, then execute that model through AscendCL. The companion [CANN post-processing sample](https://github.com/Ascend/samples/tree/master/inference/modelInference/sampleYOLOV7NMSONNX) demonstrates a CANN detection post-processing graph.
+
+The CANN samples are references, not manifests for this service. In particular, their example ATC command targets Ascend 310, so do not copy its `soc_version` for a 910B deployment. Build and validate the `.om` file in a CANN environment compatible with the destination driver and 910B SKU, and store it in a separate immutable S3 prefix. A production KServe runtime for this path must load the `.om` file through AscendCL and implement the same KServe v2 API used below. Keep the TorchScript artifact and the `torch_npu` method when conversion compatibility or a shorter implementation path is more important than native CANN optimization.
 
 The training job already uploads `1/model.pt` under `OUTPUT_MODEL_URI`. The NPU runtime consumes that file directly; it does not use Triton's `config.pbtxt`.
 
-### Prerequisites
+### Deploy the TorchScript model with `torch_npu`
+
+The remainder of this section describes the runnable TorchScript path. It retains the model artifact created by the training job and requires no ONNX or `.om` conversion.
+
+#### Prerequisites
 
 - Ascend driver, Kubernetes device plugin, and the platform's Ascend serving configuration are installed on the target nodes.
 - The `yolov5-s3` ServiceAccount and S3 credentials from [Create S3 credentials and inference ServiceAccount](#create-s3-credentials-and-inference-serviceaccount) exist in the deployment namespace.
 - The CANN image can access the host CANN libraries. Its entrypoint must source `/usr/local/Ascend/ascend-toolkit/set_env.sh` before importing `torch_npu`.
 - The exported TorchScript model is compatible with the PyTorch/CANN version in the serving image. Re-export it with the matching stack if loading fails.
 
-### Build the Ascend serving image
+#### Build the Ascend serving image
 
 Download [`yolov5-ascend.Containerfile`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend.Containerfile) and [`yolov5_ascend_server.py`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5_ascend_server.py) into the same directory. The image extends the CANN PyTorch runtime and exposes the KServe v2 health and inference endpoints for `images` and `output0`. Supply an approved, digest-pinned internal CANN base image when you build it.
 
@@ -246,7 +254,7 @@ nerdctl build \
 nerdctl push <your-registry>/yolov5-ascend:cann8.5
 ```
 
-### Register the Ascend serving runtime
+#### Register the Ascend serving runtime
 
 Download [`yolov5-ascend-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml), replace its image with the one you built, and apply it as a cluster administrator:
 
@@ -254,7 +262,7 @@ Download [`yolov5-ascend-servingruntime.yaml`](https://github.com/alauda/aml-doc
 kubectl apply -f yolov5-ascend-servingruntime.yaml
 ```
 
-### Create the Ascend inference service
+#### Create the Ascend inference service
 
 Download [`yolov5-ascend-inferenceservice.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend-inferenceservice.yaml). Set the namespace and `storageUri` to the `OUTPUT_MODEL_URI` written by the `TrainJob`. Keep `aml-model-repo` equal to `TRITON_MODEL_NAME`, because the custom runtime uses that value as its KServe v2 model name.
 

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -4,7 +4,7 @@ weight: 25
 
 # Train, Fine-Tune, and Deploy YOLOv5 with Kubeflow Trainer v2
 
-Fine-tune a YOLOv5 object-detection model on Alauda AI, package the trained model for Triton Inference Server, and publish it as an online inference service. This guide uses **Kubeflow Trainer v2** (`TrainingRuntime` and `TrainJob`), not `VolcanoJob`.
+Fine-tune a YOLOv5 object-detection model on Alauda AI, package the trained model for Triton Inference Server, and publish it as an online inference service. The base model, dataset, and output model are stored in S3-compatible object storage. This guide uses **Kubeflow Trainer v2** (`TrainingRuntime` and `TrainJob`), not `VolcanoJob`.
 
 The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDIA GPU. It runs all preparation, training, export, and publishing actions in the Trainer v2 `node` step, so it does not require a shared workspace PVC.
 
@@ -15,36 +15,51 @@ The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDI
 | Alauda AI | 1.3 or later, with Kubeflow Trainer v2 installed |
 | Hardware | x86_64 worker node with an NVIDIA GPU. NPU support requires a compatible YOLOv5 training and serving image. |
 | Access | `kubectl` permission to create `trainingruntimes` and `trainjobs` in your project namespace |
-| Model repositories | Three Git LFS-enabled repositories: a YOLOv5 base model, a dataset, and an empty output-model repository |
-| Git credentials | The `aml-image-builder-secret` secret, containing `MODEL_REPO_GIT_USER` and `MODEL_REPO_GIT_TOKEN` |
+| S3-compatible storage | A bucket with read access to the base-model and dataset prefixes and read/write access to the output-model prefix |
+| S3 credentials | The `yolov5-s3-credentials` Secret, with access key, secret key, endpoint, and region. It is also attached to the inference ServiceAccount. |
 | Image registry | A registry reachable by the training nodes, to host the custom YOLOv5 training image |
 
 The sample resources use Alauda AI's NVIDIA vGPU resource keys (`nvidia.com/gpualloc`, `nvidia.com/gpucores`, and `nvidia.com/gpumem`). If your cluster allocates whole GPUs, replace all three keys with `nvidia.com/gpu: 1` in the `TrainJob`.
 
-## Prepare the model and dataset repositories
+## Prepare S3 model and dataset objects
 
-Create the following repositories in **Model Repository**. The training pod clones each repository through its HTTPS Git URL, so the credentials secret must be able to read the first two and write the output repository.
+Create these prefixes in S3-compatible object storage. The training pod downloads the first two prefixes and uploads the deployable Triton repository to the output prefix. The output prefix must be new for every training run; do not let two jobs write to the same prefix.
 
-| Repository | Contents |
+| S3 prefix | Contents |
 | --- | --- |
-| Base model | The [YOLOv5 v7.0](https://github.com/ultralytics/yolov5/tree/v7.0) source tree, including `models/yolov5n.pt` tracked with Git LFS |
-| Dataset | The extracted [COCO128](https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip) directory. Its top level must contain `images/` and `labels/`. Track `*.jpg` with Git LFS. |
-| Output model | An empty model repository to receive the Triton model repository created by the training job |
+| `s3://<bucket>/yolov5/v7.0` | The [YOLOv5 v7.0](https://github.com/ultralytics/yolov5/tree/v7.0) source tree, including `models/yolov5n.pt` |
+| `s3://<bucket>/datasets/coco128` | The extracted [COCO128](https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip) directory. Its top level must contain `images/` and `labels/`. |
+| `s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1` | An empty, unique prefix that receives the Triton artifact layout created by the training job |
 
-YOLOv5 ignores `*.pt` by default, so remove that entry from the source tree's `.gitignore` before adding `models/yolov5n.pt`. `data/coco128.yaml` expects the dataset at `../datasets/coco128` relative to the YOLOv5 source tree. The supplied runtime clones the dataset to exactly that path. For a custom dataset, use a data YAML file in the base-model repository whose `path` matches the directory used by the runtime, or update the runtime and `DATASET_YAML` together.
+Use any S3-compatible client to upload the source tree, weight, and dataset. For example, after configuring the AWS CLI with the same endpoint and credentials as the training Secret:
 
-See [Model Repository](../../deploy/model_management/model_repository.mdx) for Git LFS model-repository usage.
+```bash
+aws --endpoint-url "$AWS_S3_ENDPOINT" s3 sync ./yolov5/ s3://<bucket>/yolov5/v7.0/
+aws --endpoint-url "$AWS_S3_ENDPOINT" s3 sync ./coco128/ s3://<bucket>/datasets/coco128/
+```
+
+`data/coco128.yaml` expects the dataset at `../datasets/coco128` relative to the YOLOv5 source tree. The supplied runtime downloads the dataset to exactly that path. For a custom dataset, use a data YAML file in the base-model prefix whose `path` matches the directory used by the runtime, or update the runtime and `DATASET_YAML` together.
+
+## Create S3 credentials and inference ServiceAccount
+
+Download [`s3-model-storage.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml). Set the namespace, endpoint, protocol, region, access key, and secret key, then apply it:
+
+```bash
+kubectl apply -f s3-model-storage.yaml
+```
+
+The Secret's `AWS_S3_ENDPOINT` value includes `http://` or `https://` for the AWS CLI. The `serving.kserve.io/s3-endpoint` annotation must omit the scheme because KServe reads its protocol from `serving.kserve.io/s3-usehttps`. This Secret is referenced directly by the `TrainJob` and indirectly by the `InferenceService` through the `yolov5-s3` ServiceAccount.
 
 ## Build the training image
 
-Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image first if your cluster cannot pull it directly. The image adds Git, Git LFS, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots.
+Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image first if your cluster cannot pull it directly. The image adds the AWS CLI, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots.
 
 ```dockerfile
 FROM nvcr.io/nvidia/pytorch:24.12-py3
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      curl ffmpeg git git-lfs libfreetype6-dev libgl1 libglib2.0-0 && \
+      curl ffmpeg libfreetype6-dev libgl1 libglib2.0-0 && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -fsSL \
@@ -52,7 +67,7 @@ RUN curl -fsSL \
       -o /tmp/requirements.txt && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r /tmp/requirements.txt && \
-    pip install --no-cache-dir Pillow==10.4.0 && \
+    pip install --no-cache-dir Pillow==10.4.0 awscli && \
     rm /tmp/requirements.txt
 
 RUN mkdir -p /opt/Ultralytics && \
@@ -92,7 +107,7 @@ kubectl apply -f yolov5-triton-trainingruntime.yaml
 kubectl get trainingruntime yolov5-triton -n <your-namespace>
 ```
 
-The runtime is reusable. It validates the required input variables, clones the model and data with Git LFS, runs `train.py`, exports `best.pt` as TorchScript, and pushes the following artifact layout to the output repository:
+The runtime is reusable. It validates the required input variables, downloads the model and data from S3, runs `train.py`, exports `best.pt` as TorchScript, and uploads the following artifact layout to the output S3 prefix:
 
 ```text
 .
@@ -106,12 +121,12 @@ This is the layout expected by Triton. `config.pbtxt` is configured for the exam
 
 ## Submit a YOLOv5 fine-tuning job
 
-Download [`yolov5-triton-trainjob.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml). Edit the namespace, the three Git URLs, and `OUTPUT_MODEL_BRANCH`; the output branch must be new or unused. Then set the resource limits and the training values that fit your cluster:
+Download [`yolov5-triton-trainjob.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml). Edit the namespace, the three S3 URIs, and `TRITON_MODEL_NAME`. `OUTPUT_MODEL_URI` must be a new prefix, and must match the inference-service `storageUri`. Then set the resource limits and the training values that fit your cluster:
 
 | Field | Default | Purpose |
 | --- | --- | --- |
-| `BASE_WEIGHTS` | `models/yolov5n.pt` | Pretrained model relative to the base-model repository |
-| `DATASET_YAML` | `data/coco128.yaml` | YOLOv5 dataset configuration relative to the base-model repository |
+| `BASE_WEIGHTS` | `models/yolov5n.pt` | Pretrained model relative to the base-model S3 prefix |
+| `DATASET_YAML` | `data/coco128.yaml` | YOLOv5 dataset configuration relative to the base-model S3 prefix |
 | `IMAGE_SIZE` | `640` | Input image width and height |
 | `BATCH_SIZE` | `16` | Per-device batch size; lower it if the GPU runs out of memory |
 | `EPOCHS` | `3` | Number of fine-tuning epochs |
@@ -127,7 +142,7 @@ kubectl get pods -n <your-namespace>
 kubectl logs -n <your-namespace> <trainer-pod-name> -c node -f
 ```
 
-When the `TrainJob` succeeds, the output model repository contains the `OUTPUT_MODEL_BRANCH` created by the job. The log includes failures from cloning, training, TorchScript export, or the Git push; no `VolcanoJob`, `vcjob`, or `PodGroup` is created.
+When the `TrainJob` succeeds, `OUTPUT_MODEL_URI` contains the deployable Triton artifact. The log includes failures from S3 download, training, TorchScript export, or S3 upload; no `VolcanoJob`, `vcjob`, or `PodGroup` is created.
 
 :::tip
 The supplied manifest is intentionally a one-node recipe. Increasing `trainer.numNodes` alone does not make YOLOv5 distributed: the runtime command must also launch a distributed training process (for example, with `torchrun`) and the data path must be reachable by every node.
@@ -143,16 +158,22 @@ kubectl apply -f triton-servingruntime.yaml
 
 The sample uses `alaudadockerhub/tritonserver:25.02-py3`, CUDA 12.1, and the `triton` model format. Change the image and accelerator labels to match the image and hardware available in your cluster. For a fuller explanation of custom serving runtimes, see [Extend Inference Runtimes](../../deploy/inference_service/guides/custom_inference_runtime.mdx).
 
-## Publish and call the inference service
+## Deploy and call the inference service
 
-1. In **Model Repository**, open the output model repository and select the `OUTPUT_MODEL_BRANCH` created by the job.
-2. In **File Management**, select **Edit Metadata**. Set **Task Type** to **Object Detection** and **Framework** to **triton**. The framework must match `supportedModelFormats` in the `ClusterServingRuntime`.
-3. Select **Publish Inference Service**. Choose the Triton runtime, configure CPU, memory, GPU, and model-cache storage, then publish.
-4. Wait for the service to be running. The **Access Method** tab provides its in-cluster URL.
+Download [`yolov5-triton-inferenceservice.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-inferenceservice.yaml). Set its namespace and `storageUri`, and make sure all of these values match the completed training run:
 
-:::note
-Model Repository reads deployment metadata from the default branch. If the **Publish Inference Service** button is unavailable while `OUTPUT_MODEL_BRANCH` is selected, set the metadata on the repository's default branch, then publish the output branch as the model version.
-:::
+- `spec.predictor.model.storageUri` is `OUTPUT_MODEL_URI`.
+- `metadata.annotations.aml-model-repo` is `TRITON_MODEL_NAME`.
+- The Triton `config.pbtxt` generated by the job uses the same `TRITON_MODEL_NAME`.
+
+Then apply and wait for the service:
+
+```bash
+kubectl apply -f yolov5-triton-inferenceservice.yaml
+kubectl get inferenceservice yolov5-coco128 -n <your-namespace> --watch
+```
+
+KServe downloads the model from S3 before starting Triton, using the credentials attached to the `yolov5-s3` ServiceAccount. See [Model Storage](../../deploy/model_management/model_storage.mdx) for the platform's S3 storage-initializer behavior.
 
 Triton serves the HTTP v2 API. From a workbench or other pod in the cluster, use this minimal client to send a normalized 640 × 640 RGB image:
 
@@ -176,7 +197,7 @@ payload = {
     "outputs": [{"name": "output0"}],
 }
 response = requests.post(
-    f"{service_url}/v2/models/<output-model-repository-name>/infer",
+    f"{service_url}/v2/models/yolov5-coco128/infer",
     json=payload,
     timeout=60,
 )

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -62,7 +62,7 @@ Do not commit populated Secret manifests. Use your managed-secret workflow or an
 
 Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image to an approved internal registry and pin it by digest before a production build. The required `BASE_IMAGE` argument makes that choice explicit. The image adds the AWS CLI, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots. For production, review or mirror the downloaded Python dependencies through your approved package source.
 
-```containerfile
+```text
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 
@@ -228,6 +228,56 @@ The Triton runtime above is for NVIDIA CUDA and cannot serve an Ascend NPU. This
 For a native CANN production implementation, use Ascend's [CANN YOLO model-inference sample](https://github.com/Ascend/samples/tree/master/inference/modelInference/sampleYOLOV7) as the reference architecture. The published sample uses YOLOv7, but its deployment flow is applicable to a compatible YOLOv5 export: export the model to ONNX, compile it with CANN ATC to an `.om` offline model, then execute that model through AscendCL. The companion [CANN post-processing sample](https://github.com/Ascend/samples/tree/master/inference/modelInference/sampleYOLOV7NMSONNX) demonstrates a CANN detection post-processing graph.
 
 The CANN samples are references, not manifests for this service. In particular, their example ATC command targets Ascend 310, so do not copy its `soc_version` for a 910B deployment. Build and validate the `.om` file in a CANN environment compatible with the destination driver and 910B SKU, and store it in a separate immutable S3 prefix. A production KServe runtime for this path must load the `.om` file through AscendCL and implement the same KServe v2 API used below. Keep the TorchScript artifact and the `torch_npu` method when conversion compatibility or a shorter implementation path is more important than native CANN optimization.
+
+### Build the native CANN compiler image
+
+Use the official CANN 910B development image as the starting point for the ATC and AscendCL path, not the `torch_npu` serving image used by the TorchScript path below. The image validated with this guide is [`quay.io/ascend/cann:9.0.1-910b-openeuler24.03-py3.11-devel`](https://quay.io/repository/ascend/cann), pinned to `sha256:0ff08aa7cbfef37690d2e092aa0dd8fe52add7e50a629f8a0920d3faa0997e06`. Mirror that digest to an approved registry reachable by the build and serving nodes before use; do not depend on public-registry access from a production pod.
+
+The development image contains `atc` and the AscendCL Python binding, but the embedded CANN Python environment does not include all ATC dependencies. Build a derived compiler image with the following tested dependency set. Install the packages into CANN's own site-packages directory: installing them only into the image's normal Python site-packages does not make them visible to the embedded compiler.
+
+```text
+ARG BASE_IMAGE=quay.io/ascend/cann@sha256:0ff08aa7cbfef37690d2e092aa0dd8fe52add7e50a629f8a0920d3faa0997e06
+FROM ${BASE_IMAGE}
+
+USER 0
+ARG CANN_PYTHON_SITE_PACKAGES=/usr/local/Ascend/cann-9.0.1/python/site-packages
+RUN python3 -m pip install --no-cache-dir --target "${CANN_PYTHON_SITE_PACKAGES}" \
+      numpy==1.26.4 \
+      decorator==5.2.1 \
+      sympy==1.13.1 \
+      mpmath==1.3.0 \
+      scipy==1.13.1 \
+      attrs==24.2.0 \
+      psutil==6.1.1
+
+# NumPy and SciPy wheels carry native libraries outside their Python packages.
+ENV LD_LIBRARY_PATH=/usr/local/Ascend/cann-9.0.1/python/site-packages/numpy.libs:/usr/local/Ascend/cann-9.0.1/python/site-packages/scipy.libs:${LD_LIBRARY_PATH}
+```
+
+Build and push that derived image with an approved build tool, for example:
+
+```bash
+nerdctl build --platform linux/arm64 -t <your-registry>/yolov5-cann-compiler:9.0.1-910b .
+nerdctl push <your-registry>/yolov5-cann-compiler:9.0.1-910b
+```
+
+Build for the target `linux/arm64` platform so that the NumPy, SciPy, and psutil wheels match the NPU node architecture. The compiler image needs package access only while it is built. In a restricted network, put the matching CPython 3.11 arm64 wheels in the build context and install them with `--no-index --find-links=<wheelhouse>`; do not give the serving workload broad outbound access merely to install dependencies at startup. Source `/usr/local/Ascend/ascend-toolkit/set_env.sh` before invoking `atc` or importing `acl`.
+
+#### Validated Ascend environment (2026-08-11)
+
+This is validation evidence from the current development cluster, not a general support matrix. Verify equivalent driver, runtime, and resource-key compatibility before using a different environment.
+
+| Component | Verified value |
+| --- | --- |
+| Nodes and architecture | Two `linux/arm64` nodes with Huawei Ascend 910B3 devices |
+| Device resource | Standard device-plugin resource `huawei.com/Ascend910`; eight allocatable devices per node at validation time |
+| Host Ascend driver | Package `25.5.0`; Ascend HAL `7.35.23`; internal version `V100R001C23SPC005B219` |
+| NPU management utility | `npu-smi 25.5.0`; allocated 910B3 device reported `Health: OK` during inference |
+| RuntimeClass | `ascend` |
+| Kubernetes device plugin | `openfuyao/ascendhub/ascend-k8sdeviceplugin:v7.3.0` |
+| Container runtime integration | `openfuyao/npu-container-toolkit:26.6.0` with the `ascend-runtime-containerd` DaemonSet |
+| NPU feature discovery | `npu-feature-discovery:v0.0.0-default.3.g20d80dd1` |
+| CANN validation | CANN `9.0.1` compiled YOLOv5n ONNX with `--soc_version=Ascend910B3`; AscendCL loaded and executed the resulting `.om` model |
 
 The training job already uploads `1/model.pt` under `OUTPUT_MODEL_URI`. The NPU runtime consumes that file directly; it does not use Triton's `config.pbtxt`.
 


### PR DESCRIPTION
## Summary
- add an end-to-end YOLOv5 fine-tuning guide using Kubeflow Trainer v2
- include reusable TrainingRuntime, TrainJob, and Triton serving-runtime manifests
- document Triton packaging, deployment, and HTTP v2 inference

## Validation
- yarn lint
- yarn build
- YAML parsing with yq