### PR TITLE
docs: add AscendCL OM inference sample

### DIFF
--- a/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml
+++ b/docs/en/train/guides/assets/yolov5/s3-model-storage.yaml
@@ -16,7 +16,7 @@ stringData:
   # Use a credential limited to the input prefixes and this run's output prefix.
   AWS_ACCESS_KEY_ID: <access-key>
   AWS_SECRET_ACCESS_KEY: <secret-key>
-  # The AWS CLI in the training image uses a complete endpoint URL.
+  # The boto3 helper in the training image uses a complete endpoint URL.
   AWS_S3_ENDPOINT: https://<s3-host>:<s3-port>
   AWS_DEFAULT_REGION: us-east-1
 ---

--- a/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml
@@ -1,7 +1,8 @@
 apiVersion: serving.kserve.io/v1alpha1
-kind: ClusterServingRuntime
+kind: ServingRuntime
 metadata:
   name: aml-triton-cuda-12
+  namespace: <your-namespace>
   annotations:
     cpaas.io/display-name: triton-cuda12-x86
   labels:

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml
@@ -1,7 +1,8 @@
 apiVersion: serving.kserve.io/v1alpha1
-kind: ClusterServingRuntime
+kind: ServingRuntime
 metadata:
   name: aml-yolov5-ascend-cann-8.5
+  namespace: <your-namespace>
   annotations:
     cpaas.io/display-name: yolov5-ascend-cann8.5
   labels:

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-inferenceservice.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-inferenceservice.yaml
@@ -1,0 +1,38 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: yolov5-coco128-ascendcl-om
+  namespace: <your-namespace>
+  annotations:
+    aml-model-repo: yolov5-coco128
+    aml-pipeline-tag: object-detection
+    serving.kserve.io/deploymentMode: Standard
+  labels:
+    aml.cpaas.io/runtime-type: ascendcl
+spec:
+  predictor:
+    minReplicas: 1
+    maxReplicas: 1
+    serviceAccountName: yolov5-s3
+    model:
+      name: ""
+      modelFormat:
+        name: cann-om
+      protocolVersion: v2
+      runtime: aml-yolov5-ascendcl-om-cann-9
+      # This prefix contains only 1/model.om for the compiled target SKU.
+      storageUri: s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-ascend910b3-cann9.0.1
+      resources:
+        requests:
+          cpu: "2"
+          memory: 6Gi
+        limits:
+          cpu: "2"
+          memory: 6Gi
+          huawei.com/Ascend910: "1"
+    securityContext:
+      fsGroup: 1000
+      seccompProfile:
+        type: RuntimeDefault
+      supplementalGroups:
+        - 1000

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml
@@ -1,0 +1,74 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ClusterServingRuntime
+metadata:
+  name: aml-yolov5-ascendcl-om-cann-9
+  annotations:
+    cpaas.io/display-name: yolov5-ascendcl-om-cann9
+  labels:
+    cpaas.io/accelerator-type: ascend
+    cpaas.io/cann-version: "9.0.1"
+    cpaas.io/runtime-class: ascendcl
+spec:
+  containers:
+    - name: kserve-container
+      # Build this image from yolov5-ascendcl-om.Containerfile and
+      # yolov5_ascendcl_om_server.py. Use an approved, digest-pinned mirror.
+      image: <your-registry>/yolov5-ascendcl-om:cann9.0.1
+      command:
+        - bash
+        - -c
+        - |
+          set -e
+          source /usr/local/Ascend/ascend-toolkit/set_env.sh
+          exec uvicorn ascendcl_om_server:app --app-dir /opt/yolov5 --host 0.0.0.0 --port 8080
+      env:
+        - name: MODEL_NAME
+          value: '{{ index .Annotations "aml-model-repo" }}'
+        - name: MODEL_PATH
+          value: /mnt/models/1/model.om
+        - name: ASCEND_DEVICE_ID
+          value: "0"
+        - name: HOME
+          value: /tmp
+        - name: USER
+          value: yolo
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      startupProbe:
+        httpGet:
+          path: /v2/models/{{ index .Annotations "aml-model-repo" }}/ready
+          port: 8080
+          scheme: HTTP
+        failureThreshold: 60
+        periodSeconds: 10
+        timeoutSeconds: 10
+      readinessProbe:
+        httpGet:
+          path: /v2/health/ready
+          port: 8080
+          scheme: HTTP
+        periodSeconds: 10
+        timeoutSeconds: 10
+  protocolVersions:
+    - v2
+  supportedModelFormats:
+    - name: cann-om
+      version: "1"

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml
@@ -1,7 +1,8 @@
 apiVersion: serving.kserve.io/v1alpha1
-kind: ClusterServingRuntime
+kind: ServingRuntime
 metadata:
   name: aml-yolov5-ascendcl-om-cann-9
+  namespace: <your-namespace>
   annotations:
     cpaas.io/display-name: yolov5-ascendcl-om-cann9
   labels:

--- a/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om.Containerfile
+++ b/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om.Containerfile
@@ -1,0 +1,16 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER 0
+RUN python3 -m pip install --no-cache-dir \
+      fastapi==0.115.6 \
+      "uvicorn[standard]==0.34.0" \
+      numpy==1.26.4
+
+COPY --chown=1000:1000 yolov5_ascendcl_om_server.py /opt/yolov5/ascendcl_om_server.py
+RUN chmod 0555 /opt/yolov5/ascendcl_om_server.py
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD python3 -c "from urllib.request import urlopen; urlopen('http://127.0.0.1:8080/v2/health/ready', timeout=2)" || exit 1
+
+USER 1000

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
@@ -57,11 +57,11 @@ spec:
                           TRAIN_DIR="${WORKSPACE}/runs/train"
                           TRITON_MODEL_DIR="${WORKSPACE}/triton-model"
                           # Download the YOLOv5 source, pretrained weight, and dataset from
-                          # S3-compatible object storage. The TrainJob supplies the AWS credentials.
-                          aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
+                          # S3-compatible object storage. The TrainJob supplies the credentials.
+                          python /opt/yolov5/yolov5_s3_transfer.py sync \
                             "${BASE_MODEL_URI}" "${MODEL_DIR}"
                           mkdir -p "${WORKSPACE}/datasets"
-                          aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
+                          python /opt/yolov5/yolov5_s3_transfer.py sync \
                             "${DATASET_URI}" "${DATASET_DIR}"
 
                           cd "${MODEL_DIR}"
@@ -123,11 +123,11 @@ spec:
                           EOF
 
                           # Upload the deployable Triton artifact layout to a new, immutable S3 prefix.
-                          aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
+                          python /opt/yolov5/yolov5_s3_transfer.py sync \
                             "${TRITON_MODEL_DIR}" "${OUTPUT_MODEL_URI}"
                           if [ -n "${OUTPUT_ONNX_URI:-}" ]; then
                             # Keep the ONNX export in a separate immutable prefix for CANN ATC conversion.
-                            aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 cp \
+                            python /opt/yolov5/yolov5_s3_transfer.py copy \
                               "${TRAIN_DIR}/weights/best.onnx" "${OUTPUT_ONNX_URI%/}/model.onnx"
                           fi
                       volumeMounts:

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainingruntime.yaml
@@ -83,6 +83,13 @@ spec:
                             --include torchscript \
                             --device "${DEVICE}"
                           test -f "${TRAIN_DIR}/weights/best.torchscript"
+                          if [ -n "${OUTPUT_ONNX_URI:-}" ]; then
+                            python export.py \
+                              --weights "${TRAIN_DIR}/weights/best.pt" \
+                              --include onnx \
+                              --device "${DEVICE}"
+                            test -f "${TRAIN_DIR}/weights/best.onnx"
+                          fi
 
                           # Triton requires a versioned model directory and config.pbtxt at
                           # the repository root. This configuration is for the COCO-80,
@@ -118,6 +125,11 @@ spec:
                           # Upload the deployable Triton artifact layout to a new, immutable S3 prefix.
                           aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 sync \
                             "${TRITON_MODEL_DIR}" "${OUTPUT_MODEL_URI}"
+                          if [ -n "${OUTPUT_ONNX_URI:-}" ]; then
+                            # Keep the ONNX export in a separate immutable prefix for CANN ATC conversion.
+                            aws --endpoint-url "${AWS_S3_ENDPOINT}" s3 cp \
+                              "${TRAIN_DIR}/weights/best.onnx" "${OUTPUT_ONNX_URI%/}/model.onnx"
+                          fi
                       volumeMounts:
                         - name: workspace
                           mountPath: /workspace

--- a/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml
+++ b/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml
@@ -19,6 +19,8 @@ spec:
         value: s3://<bucket>/datasets/coco128
       - name: OUTPUT_MODEL_URI
         value: s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1
+      - name: OUTPUT_ONNX_URI
+        value: s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-onnx
       - name: TRITON_MODEL_NAME
         value: yolov5-coco128
       - name: AWS_ACCESS_KEY_ID

--- a/docs/en/train/guides/assets/yolov5/yolov5_ascendcl_om_server.py
+++ b/docs/en/train/guides/assets/yolov5/yolov5_ascendcl_om_server.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from threading import Lock
+
+import acl
+import numpy as np
+from fastapi import FastAPI, HTTPException
+
+
+ACL_SUCCESS = 0
+ACL_FLOAT = 0
+ACL_MEM_MALLOC_NORMAL_ONLY = 2
+ACL_MEMCPY_HOST_TO_DEVICE = 1
+ACL_MEMCPY_DEVICE_TO_HOST = 2
+ACL_MEMCPY_DEVICE_TO_DEVICE = 3
+ACL_HOST = 1
+MODEL_NAME = os.environ.get("MODEL_NAME", "yolov5-coco128")
+MODEL_PATH = os.environ.get("MODEL_PATH", "/mnt/models/1/model.om")
+DEVICE_ID = int(os.environ.get("ASCEND_DEVICE_ID", "0"))
+INPUT_SHAPE = (1, 3, 640, 640)
+app = FastAPI()
+
+
+def check_acl(operation: str, result: int):
+    if result != ACL_SUCCESS:
+        raise RuntimeError(f"{operation} failed with error code {result}")
+
+
+class AscendCLModel:
+    def __init__(self, model_path: str, device_id: int):
+        if not os.path.isfile(model_path):
+            raise RuntimeError(f"CANN offline model not found: {model_path}")
+
+        self.device_id = device_id
+        self.context = None
+        self.model_id = None
+        self.model_desc = None
+        self.input_dataset = None
+        self.output_dataset = None
+        self.input_buffer = None
+        self.input_size = 0
+        self.output_buffers = []
+        self.lock = Lock()
+        self.closed = False
+
+        check_acl("acl.init", acl.init())
+        check_acl("acl.rt.set_device", acl.rt.set_device(self.device_id))
+        self.context, result = acl.rt.create_context(self.device_id)
+        check_acl("acl.rt.create_context", result)
+        self._activate()
+
+        self.model_id, result = acl.mdl.load_from_file(model_path)
+        check_acl("acl.mdl.load_from_file", result)
+        self.model_desc = acl.mdl.create_desc()
+        check_acl("acl.mdl.get_desc", acl.mdl.get_desc(self.model_desc, self.model_id))
+
+        if acl.mdl.get_num_inputs(self.model_desc) != 1:
+            raise RuntimeError("This sample requires an .om model with one input")
+        if acl.mdl.get_num_outputs(self.model_desc) != 1:
+            raise RuntimeError("This sample requires an .om model with one output")
+        if acl.mdl.get_input_data_type(self.model_desc, 0) != ACL_FLOAT:
+            raise RuntimeError("This sample requires an .om model with one FP32 input")
+        if acl.mdl.get_output_data_type(self.model_desc, 0) != ACL_FLOAT:
+            raise RuntimeError("This sample requires an .om model with one FP32 output")
+
+        self.input_size = acl.mdl.get_input_size_by_index(self.model_desc, 0)
+        expected_input_size = int(np.prod(INPUT_SHAPE)) * np.dtype(np.float32).itemsize
+        if self.input_size != expected_input_size:
+            raise RuntimeError(
+                "The .om input size does not match the sample's fixed FP32 "
+                f"input shape {list(INPUT_SHAPE)}"
+            )
+        self.input_dataset = acl.mdl.create_dataset()
+        self.input_buffer, result = acl.rt.malloc(self.input_size, ACL_MEM_MALLOC_NORMAL_ONLY)
+        check_acl("acl.rt.malloc input", result)
+        input_data = acl.create_data_buffer(self.input_buffer, self.input_size)
+        _, result = acl.mdl.add_dataset_buffer(self.input_dataset, input_data)
+        check_acl("acl.mdl.add_dataset_buffer input", result)
+
+        self.output_dataset = acl.mdl.create_dataset()
+        output_size = acl.mdl.get_output_size_by_index(self.model_desc, 0)
+        output_buffer, result = acl.rt.malloc(output_size, ACL_MEM_MALLOC_NORMAL_ONLY)
+        check_acl("acl.rt.malloc output", result)
+        output_data = acl.create_data_buffer(output_buffer, output_size)
+        _, result = acl.mdl.add_dataset_buffer(self.output_dataset, output_data)
+        check_acl("acl.mdl.add_dataset_buffer output", result)
+        self.output_buffers.append((output_buffer, output_size))
+
+        self.run_mode, result = acl.rt.get_run_mode()
+        check_acl("acl.rt.get_run_mode", result)
+
+    def _activate(self):
+        check_acl("acl.rt.set_current_context", acl.rt.set_current_context(self.context))
+
+    def infer(self, image: np.ndarray) -> np.ndarray:
+        if image.shape != INPUT_SHAPE or image.dtype != np.float32:
+            raise ValueError(f"images must be FP32 with shape {list(INPUT_SHAPE)}")
+        image = np.ascontiguousarray(image)
+
+        with self.lock:
+            self._activate()
+            copy_kind = ACL_MEMCPY_HOST_TO_DEVICE if self.run_mode == ACL_HOST else ACL_MEMCPY_DEVICE_TO_DEVICE
+            source = acl.util.numpy_to_ptr(image)
+            check_acl(
+                "acl.rt.memcpy input",
+                acl.rt.memcpy(self.input_buffer, self.input_size, source, image.nbytes, copy_kind),
+            )
+            check_acl("acl.mdl.execute", acl.mdl.execute(self.model_id, self.input_dataset, self.output_dataset))
+
+            dims, result = acl.mdl.get_cur_output_dims(self.model_desc, 0)
+            check_acl("acl.mdl.get_cur_output_dims", result)
+            output_shape = tuple(dims["dims"])
+            output = np.empty(output_shape, dtype=np.float32)
+            output_size = output.nbytes
+            output_buffer, allocated_size = self.output_buffers[0]
+            if output_size > allocated_size:
+                raise RuntimeError("The .om output is larger than its allocated output buffer")
+            destination = acl.util.numpy_to_ptr(output)
+            copy_kind = ACL_MEMCPY_DEVICE_TO_HOST if self.run_mode == ACL_HOST else ACL_MEMCPY_DEVICE_TO_DEVICE
+            check_acl(
+                "acl.rt.memcpy output",
+                acl.rt.memcpy(destination, output_size, output_buffer, output_size, copy_kind),
+            )
+            return output
+
+    def close(self):
+        if self.closed:
+            return
+        self.closed = True
+        if self.context is not None:
+            self._activate()
+        for dataset in (self.input_dataset, self.output_dataset):
+            if dataset is None:
+                continue
+            for index in range(acl.mdl.get_dataset_num_buffers(dataset)):
+                data = acl.mdl.get_dataset_buffer(dataset, index)
+                if data is not None:
+                    acl.destroy_data_buffer(data)
+            acl.mdl.destroy_dataset(dataset)
+        if self.input_buffer is not None:
+            acl.rt.free(self.input_buffer)
+        for buffer, _ in self.output_buffers:
+            acl.rt.free(buffer)
+        if self.model_id is not None:
+            acl.mdl.unload(self.model_id)
+        if self.model_desc is not None:
+            acl.mdl.destroy_desc(self.model_desc)
+        if self.context is not None:
+            acl.rt.destroy_context(self.context)
+        acl.rt.reset_device(self.device_id)
+        acl.finalize()
+
+
+@lru_cache(maxsize=1)
+def model():
+    return AscendCLModel(MODEL_PATH, DEVICE_ID)
+
+
+@app.on_event("startup")
+def load_model():
+    model()
+
+
+@app.on_event("shutdown")
+def unload_model():
+    if model.cache_info().currsize:
+        model().close()
+        model.cache_clear()
+
+
+@app.get("/v2/health/live")
+@app.get("/v2/health/ready")
+@app.get("/v2/models/{model_name}/ready")
+def ready(model_name: str | None = None):
+    if model_name is not None and model_name != MODEL_NAME:
+        raise HTTPException(status_code=404, detail="Unknown model")
+    model()
+    return {}
+
+
+@app.post("/v2/models/{model_name}/infer")
+def infer(model_name: str, request: dict):
+    if model_name != MODEL_NAME:
+        raise HTTPException(status_code=404, detail="Unknown model")
+
+    inputs = request.get("inputs", [])
+    image = next((item for item in inputs if item.get("name") == "images"), None)
+    if image is None:
+        raise HTTPException(status_code=400, detail="Missing FP32 input named images")
+    if image.get("datatype") != "FP32":
+        raise HTTPException(status_code=400, detail="images must use FP32 data")
+
+    shape = image.get("shape")
+    data = image.get("data")
+    if shape != list(INPUT_SHAPE) or not isinstance(data, list):
+        raise HTTPException(status_code=400, detail=f"images must have shape {list(INPUT_SHAPE)}")
+    if len(data) != int(np.prod(INPUT_SHAPE)):
+        raise HTTPException(status_code=400, detail="images data does not match shape")
+
+    try:
+        values = np.asarray(data, dtype=np.float32).reshape(INPUT_SHAPE)
+        output = model().infer(values)
+    except (TypeError, ValueError) as error:
+        raise HTTPException(status_code=400, detail="images data must contain FP32 values") from error
+    except RuntimeError as error:
+        raise HTTPException(status_code=500, detail="AscendCL inference failed") from error
+
+    return {
+        "model_name": MODEL_NAME,
+        "model_version": "1",
+        "outputs": [
+            {
+                "name": "output0",
+                "datatype": "FP32",
+                "shape": list(output.shape),
+                "data": output.flatten().tolist(),
+            }
+        ],
+    }

--- a/docs/en/train/guides/assets/yolov5/yolov5_s3_transfer.py
+++ b/docs/en/train/guides/assets/yolov5/yolov5_s3_transfer.py
@@ -1,0 +1,144 @@
+"""Copy files and directory prefixes to or from S3-compatible storage."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
+
+import boto3
+from botocore.config import Config
+
+
+def s3_location(uri: str) -> tuple[str, str]:
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise ValueError(f"Expected an S3 URI, got {uri!r}")
+    return parsed.netloc, parsed.path.lstrip("/")
+
+
+def is_s3_uri(value: str) -> bool:
+    return value.startswith("s3://")
+
+
+def s3_client():
+    endpoint = os.environ.get("AWS_S3_ENDPOINT")
+    if not endpoint:
+        raise RuntimeError("Set AWS_S3_ENDPOINT to the S3-compatible endpoint URL")
+    session = boto3.Session(region_name=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+    return session.client(
+        "s3",
+        endpoint_url=endpoint,
+        config=Config(s3={"addressing_style": "path"}),
+    )
+
+
+def safe_destination(root: Path, relative_key: str) -> Path:
+    relative_path = PurePosixPath(relative_key)
+    if not relative_key or relative_path.is_absolute() or ".." in relative_path.parts:
+        raise ValueError(f"Unsafe object key relative to S3 prefix: {relative_key!r}")
+    root = root.resolve()
+    destination = (root / Path(*relative_path.parts)).resolve()
+    try:
+        destination.relative_to(root)
+    except ValueError as error:
+        raise ValueError(f"Object key escapes destination directory: {relative_key!r}") from error
+    return destination
+
+
+def download_file(client, bucket: str, key: str, destination: Path):
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=destination.parent, delete=False) as temporary:
+        temporary_path = Path(temporary.name)
+    try:
+        client.download_file(bucket, key, str(temporary_path))
+        temporary_path.replace(destination)
+    except BaseException:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def download_prefix(client, source: str, destination: Path):
+    bucket, prefix = s3_location(source)
+    prefix = prefix.rstrip("/") + "/"
+    downloaded = 0
+    for page in client.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix):
+        for item in page.get("Contents", []):
+            key = item["Key"]
+            relative_key = key.removeprefix(prefix)
+            if not relative_key:
+                continue
+            target = safe_destination(destination, relative_key)
+            print(f"download s3://{bucket}/{key} -> {target}")
+            download_file(client, bucket, key, target)
+            downloaded += 1
+    if not downloaded:
+        raise RuntimeError(f"No objects found under {source}")
+
+
+def upload_prefix(client, source: Path, destination: str):
+    bucket, prefix = s3_location(destination)
+    prefix = prefix.rstrip("/")
+    uploaded = 0
+    for path in source.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"Refusing to upload symbolic link: {path}")
+        if not path.is_file():
+            continue
+        key = "/".join(part for part in (prefix, path.relative_to(source).as_posix()) if part)
+        print(f"upload {path} -> s3://{bucket}/{key}")
+        client.upload_file(str(path), bucket, key)
+        uploaded += 1
+    if not uploaded:
+        raise RuntimeError(f"No regular files found under {source}")
+
+
+def sync(source: str, destination: str):
+    client = s3_client()
+    if is_s3_uri(source) and not is_s3_uri(destination):
+        download_prefix(client, source, Path(destination))
+    elif not is_s3_uri(source) and is_s3_uri(destination):
+        local_source = Path(source)
+        if not local_source.is_dir():
+            raise ValueError(f"sync source must be a directory: {local_source}")
+        upload_prefix(client, local_source, destination)
+    else:
+        raise ValueError("sync requires one local directory and one S3 URI")
+
+
+def copy_file(source: str, destination: str):
+    client = s3_client()
+    if is_s3_uri(source) and not is_s3_uri(destination):
+        bucket, key = s3_location(source)
+        download_file(client, bucket, key, Path(destination))
+    elif not is_s3_uri(source) and is_s3_uri(destination):
+        local_source = Path(source)
+        if not local_source.is_file() or local_source.is_symlink():
+            raise ValueError(f"copy source must be a regular file: {local_source}")
+        bucket, key = s3_location(destination)
+        if not key:
+            raise ValueError("copy destination must include an object key")
+        print(f"upload {local_source} -> s3://{bucket}/{key}")
+        client.upload_file(str(local_source), bucket, key)
+    else:
+        raise ValueError("copy requires one local file and one S3 URI")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("sync", "copy"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("source")
+        subparser.add_argument("destination")
+    args = parser.parse_args()
+    if args.command == "sync":
+        sync(args.source, args.destination)
+    else:
+        copy_file(args.source, args.destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -131,9 +131,11 @@ The runtime is reusable. It validates the required input variables, downloads th
 
 This is the layout expected by Triton. `config.pbtxt` is configured for the example's 640 × 640 COCO model. If you change the input image size or the model output signature, update the config in the runtime before training. Confirm the input and output names and shapes with the exported model before publishing a custom model.
 
+When `OUTPUT_ONNX_URI` is set, the runtime also writes `model.onnx` to that separate prefix. It is the input artifact for the native CANN deployment path described below. Omit that variable for a Triton-only training run.
+
 ## Submit a YOLOv5 fine-tuning job
 
-Download [`yolov5-triton-trainjob.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml). Edit the namespace, the three S3 URIs, and `TRITON_MODEL_NAME`. `OUTPUT_MODEL_URI` must be a new prefix, and must match the inference-service `storageUri`. Then set the resource limits and the training values that fit your cluster:
+Download [`yolov5-triton-trainjob.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-triton-trainjob.yaml). Edit the namespace, the three required S3 URIs, and `TRITON_MODEL_NAME`. Set `OUTPUT_ONNX_URI` as a fourth S3 URI only when following the native CANN path. Every output URI must be a new prefix. `OUTPUT_MODEL_URI` must match the Triton inference-service `storageUri`. Then set the resource limits and the training values that fit your cluster:
 
 | Field | Default | Purpose |
 | --- | --- | --- |
@@ -144,6 +146,7 @@ Download [`yolov5-triton-trainjob.yaml`](https://github.com/alauda/aml-docs/blob
 | `EPOCHS` | `3` | Number of fine-tuning epochs |
 | `DATALOADER_WORKERS` | `0` | Data-loader workers; raise only after confirming the shared-memory allocation is sufficient |
 | `DEVICE` | `0` | GPU index; set `cpu` for CPU-only testing and remove GPU resource requests |
+| `OUTPUT_ONNX_URI` | `s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-onnx` | Optional separate prefix that receives the exported `model.onnx` for ATC conversion |
 
 Create and watch the job:
 
@@ -223,11 +226,11 @@ The raw output contains candidate boxes and class scores. YOLOv5 post-processing
 
 ## Deploy on Ascend NPU \{#deploy-on-ascend-npu}
 
-The Triton runtime above is for NVIDIA CUDA and cannot serve an Ascend NPU. This guide provides a runnable custom KServe runtime that loads the exported TorchScript model with `torch_npu`. It targets arm64 Ascend 910B4 nodes with CANN 8.5; adjust the image, CANN version, and resource keys for other Ascend hardware.
+The Triton runtime above is for NVIDIA CUDA and cannot serve an Ascend NPU. This guide provides two runnable NPU paths: a custom KServe runtime that loads the exported TorchScript model with `torch_npu`, and a native CANN path that loads an ATC-compiled `.om` model with AscendCL. Adjust the image, CANN version, and resource keys for the destination Ascend hardware.
 
 For a native CANN production implementation, use Ascend's [CANN YOLO model-inference sample](https://github.com/Ascend/samples/tree/master/inference/modelInference/sampleYOLOV7) as the reference architecture. The published sample uses YOLOv7, but its deployment flow is applicable to a compatible YOLOv5 export: export the model to ONNX, compile it with CANN ATC to an `.om` offline model, then execute that model through AscendCL. The companion [CANN post-processing sample](https://github.com/Ascend/samples/tree/master/inference/modelInference/sampleYOLOV7NMSONNX) demonstrates a CANN detection post-processing graph.
 
-The CANN samples are references, not manifests for this service. In particular, their example ATC command targets Ascend 310, so do not copy its `soc_version` for a 910B deployment. Build and validate the `.om` file in a CANN environment compatible with the destination driver and 910B SKU, and store it in a separate immutable S3 prefix. A production KServe runtime for this path must load the `.om` file through AscendCL and implement the same KServe v2 API used below. Keep the TorchScript artifact and the `torch_npu` method when conversion compatibility or a shorter implementation path is more important than native CANN optimization.
+The CANN samples are references, not manifests for this service. In particular, their example ATC command targets Ascend 310, so do not copy its `soc_version` for a 910B deployment. Build and validate the `.om` file in a CANN environment compatible with the destination driver and 910B SKU, and store it in a separate immutable S3 prefix. The runnable AscendCL sample below implements the same KServe v2 API as the TorchScript sample. Keep the TorchScript artifact and the `torch_npu` method when conversion compatibility or a shorter implementation path is more important than native CANN optimization.
 
 ### Build the native CANN compiler image
 
@@ -241,7 +244,8 @@ FROM ${BASE_IMAGE}
 
 USER 0
 ARG CANN_PYTHON_SITE_PACKAGES=/usr/local/Ascend/cann-9.0.1/python/site-packages
-RUN python3 -m pip install --no-cache-dir --target "${CANN_PYTHON_SITE_PACKAGES}" \
+RUN python3 -m pip install --no-cache-dir awscli==1.46.0 && \
+    python3 -m pip install --no-cache-dir --target "${CANN_PYTHON_SITE_PACKAGES}" \
       numpy==1.26.4 \
       decorator==5.2.1 \
       sympy==1.13.1 \
@@ -262,6 +266,72 @@ nerdctl push <your-registry>/yolov5-cann-compiler:9.0.1-910b
 ```
 
 Build for the target `linux/arm64` platform so that the NumPy, SciPy, and psutil wheels match the NPU node architecture. The compiler image needs package access only while it is built. In a restricted network, put the matching CPython 3.11 arm64 wheels in the build context and install them with `--no-index --find-links=<wheelhouse>`; do not give the serving workload broad outbound access merely to install dependencies at startup. Source `/usr/local/Ascend/ascend-toolkit/set_env.sh` before invoking `atc` or importing `acl`.
+
+### Deploy a compiled `.om` model with AscendCL
+
+This path serves a static-batch, FP32 YOLOv5 model compiled for one Ascend SKU. It uses a separate S3 prefix containing exactly this layout:
+
+```text
+.
+└── 1/
+    └── model.om
+```
+
+Do not put the TorchScript Triton repository, the ONNX source, or a model compiled for a different `soc_version` in this prefix. An `.om` file is an executable CANN offline model, not a portable interchange format. Recompile and use a new immutable prefix whenever the target Ascend SKU or incompatible CANN/driver stack changes.
+
+#### Compile and publish the offline model
+
+Start a container from the compiler image built above. Download `model.onnx` from `OUTPUT_ONNX_URI`, then compile it for the destination SKU. This command is for the fixed `images:1,3,640,640` FP32 input used by the supplied KServe server and must be changed together with the server if the model signature changes:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+aws --endpoint-url "$AWS_S3_ENDPOINT" s3 cp \
+  s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-onnx/model.onnx \
+  /work/model.onnx
+atc \
+  --framework=5 \
+  --model=/work/model.onnx \
+  --output=/work/model \
+  --input_format=NCHW \
+  --input_shape="images:1,3,640,640" \
+  --soc_version=Ascend910B3
+aws --endpoint-url "$AWS_S3_ENDPOINT" s3 cp \
+  /work/model.om \
+  s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-ascend910b3-cann9.0.1/1/model.om
+```
+
+`atc` writes `/work/model.om`. The commands assume an S3-compatible client configured with the same endpoint and least-privilege credentials used by the training workflow. The output prefix must be new and contain only `1/model.om`. Do not use the sample `Ascend910B3` value for a different SKU.
+
+#### Build the AscendCL serving image
+
+Download [`yolov5-ascendcl-om.Containerfile`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om.Containerfile) and [`yolov5_ascendcl_om_server.py`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5_ascendcl_om_server.py) into the same directory. Build the image from the derived CANN compiler image above, or an equivalent CANN runtime image that provides the AscendCL Python binding and is compatible with the target driver:
+
+```bash
+nerdctl build --platform linux/arm64 \
+  --build-arg BASE_IMAGE=<your-registry>/yolov5-cann-compiler:9.0.1-910b@sha256:<digest> \
+  -f yolov5-ascendcl-om.Containerfile \
+  -t <your-registry>/yolov5-ascendcl-om:cann9.0.1 .
+nerdctl push <your-registry>/yolov5-ascendcl-om:cann9.0.1
+```
+
+The server initializes AscendCL once, loads `/mnt/models/1/model.om`, validates the fixed input shape, and serializes calls to its ACL context. It exposes KServe v2 health and inference endpoints and returns the raw `output0` tensor. As with the TorchScript path, YOLO confidence filtering and non-maximum suppression remain client responsibilities.
+
+#### Register the AscendCL runtime and deploy the service
+
+Download [`yolov5-ascendcl-om-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml), replace its image with the image you pushed, and apply it as a cluster administrator:
+
+```bash
+kubectl apply -f yolov5-ascendcl-om-servingruntime.yaml
+```
+
+Then download [`yolov5-ascendcl-om-inferenceservice.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-inferenceservice.yaml). Set the namespace and `storageUri` to the immutable S3 prefix containing `1/model.om`, and keep `aml-model-repo` equal to the KServe v2 model name:
+
+```bash
+kubectl apply -f yolov5-ascendcl-om-inferenceservice.yaml
+kubectl get inferenceservice yolov5-coco128-ascendcl-om -n <your-namespace> --watch
+```
+
+The supplied `InferenceService` requests one whole device with the standard Huawei device-plugin key, `huawei.com/Ascend910: "1"`. If your cluster uses HAMI vNPU slices, replace that limit with the resource keys and memory value required by the cluster's Ascend scheduling configuration. Use the same S3 ServiceAccount created in [Create S3 credentials and inference ServiceAccount](#create-s3-credentials-and-inference-serviceaccount) so KServe can download the offline model.
 
 #### Validated Ascend environment (2026-08-11)
 

--- a/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
+++ b/docs/en/train/guides/yolov5-training-and-triton-deployment.mdx
@@ -14,7 +14,7 @@ The example fine-tunes YOLOv5n v7.0 on the COCO128 sample dataset with one NVIDI
 | --- | --- |
 | Alauda AI | 1.3 or later, with Kubeflow Trainer v2 installed |
 | Hardware | x86_64 worker node with an NVIDIA GPU for the default Triton path. See [Deploy on Ascend NPU](#deploy-on-ascend-npu) for the separate arm64 NPU serving path. |
-| Access | Least-privilege `kubectl` permission to create `trainingruntimes` and `trainjobs` in your project namespace; cluster-administrator access only when creating a `ClusterServingRuntime` |
+| Access | Least-privilege `kubectl` permission to create `trainingruntimes`, `trainjobs`, `servingruntimes`, and `inferenceservices` in your project namespace |
 | S3-compatible storage | A bucket with read access to the base-model and dataset prefixes and read/write access to the output-model prefix |
 | S3 credentials | The `yolov5-s3-credentials` Secret, with an access key, secret key, endpoint, and region. Grant it only the required source reads and output writes. It is also attached to the inference ServiceAccount. |
 | Image registry | An approved registry reachable by the training and serving nodes, to host pinned YOLOv5 and Triton images |
@@ -31,11 +31,12 @@ Create these prefixes in S3-compatible object storage. The training pod download
 | `s3://<bucket>/datasets/coco128` | The extracted [COCO128](https://github.com/ultralytics/yolov5/releases/download/v1.0/coco128.zip) directory. Its top level must contain `images/` and `labels/`. |
 | `s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1` | An empty, unique prefix that receives the Triton artifact layout created by the training job |
 
-Use any S3-compatible client to upload the source tree, weight, and dataset. For example, after configuring the AWS CLI with the same endpoint and credentials as the training Secret:
+Download [`yolov5_s3_transfer.py`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5_s3_transfer.py), install its dependency, and set the same standard S3 environment variables as the training Secret (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_S3_ENDPOINT`, and `AWS_DEFAULT_REGION`). Then upload the source tree, weight, and dataset with the included `boto3` helper:
 
 ```bash
-aws --endpoint-url "$AWS_S3_ENDPOINT" s3 sync ./yolov5/ s3://<bucket>/yolov5/v7.0/
-aws --endpoint-url "$AWS_S3_ENDPOINT" s3 sync ./coco128/ s3://<bucket>/datasets/coco128/
+python3 -m pip install boto3==1.42.97
+python3 yolov5_s3_transfer.py sync ./yolov5/ s3://<bucket>/yolov5/v7.0/
+python3 yolov5_s3_transfer.py sync ./coco128/ s3://<bucket>/datasets/coco128/
 ```
 
 `data/coco128.yaml` expects the dataset at `../datasets/coco128` relative to the YOLOv5 source tree. The supplied runtime downloads the dataset to exactly that path. For a custom dataset, use a data YAML file in the base-model prefix whose `path` matches the directory used by the runtime, or update the runtime and `DATASET_YAML` together.
@@ -52,7 +53,7 @@ Download [`s3-model-storage.yaml`](https://github.com/alauda/aml-docs/blob/maste
 kubectl apply -f s3-model-storage.yaml
 ```
 
-The Secret's `AWS_S3_ENDPOINT` value includes `http://` or `https://` for the AWS CLI. The `serving.kserve.io/s3-endpoint` annotation must omit the scheme because KServe reads its protocol from `serving.kserve.io/s3-usehttps`. This Secret is referenced directly by the `TrainJob` and indirectly by the `InferenceService` through the `yolov5-s3` ServiceAccount.
+The Secret's `AWS_S3_ENDPOINT` value includes `http://` or `https://` for the included `boto3` helper. The `serving.kserve.io/s3-endpoint` annotation must omit the scheme because KServe reads its protocol from `serving.kserve.io/s3-usehttps`. This Secret is referenced directly by the `TrainJob` and indirectly by the `InferenceService` through the `yolov5-s3` ServiceAccount.
 
 :::caution
 Do not commit populated Secret manifests. Use your managed-secret workflow or an ignored local copy, and rotate the credentials after an incident. Scope the credential to read only the base-model and dataset prefixes and to write only the unique output-model prefix. Keep `s3-usehttps: "1"` for production; use HTTP only for a private test endpoint after accepting the transport risk.
@@ -60,7 +61,7 @@ Do not commit populated Secret manifests. Use your managed-secret workflow or an
 
 ## Build the training image
 
-Build and push an image based on the following `Containerfile`. Mirror the NVIDIA base image to an approved internal registry and pin it by digest before a production build. The required `BASE_IMAGE` argument makes that choice explicit. The image adds the AWS CLI, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots. For production, review or mirror the downloaded Python dependencies through your approved package source.
+Build and push an image based on the following `Containerfile`. Save the downloaded `yolov5_s3_transfer.py` beside the `Containerfile`. Mirror the NVIDIA base image to an approved internal registry and pin it by digest before a production build. The required `BASE_IMAGE` argument makes that choice explicit. The image adds `boto3`, YOLOv5 v7.0 dependencies, and the font files YOLOv5 needs for result plots. For production, review or mirror the downloaded Python dependencies through your approved package source.
 
 ```text
 ARG BASE_IMAGE
@@ -76,8 +77,11 @@ RUN curl -fsSL \
       -o /tmp/requirements.txt && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r /tmp/requirements.txt && \
-    pip install --no-cache-dir Pillow==10.4.0 awscli && \
+    pip install --no-cache-dir Pillow==10.4.0 boto3==1.42.97 && \
     rm /tmp/requirements.txt
+
+COPY --chown=1000:1000 yolov5_s3_transfer.py /opt/yolov5/yolov5_s3_transfer.py
+RUN chmod 0555 /opt/yolov5/yolov5_s3_transfer.py
 
 RUN mkdir -p /opt/Ultralytics && \
     curl -fsSL https://ultralytics.com/assets/Arial.ttf \
@@ -165,7 +169,7 @@ The supplied manifest is intentionally a one-node recipe. Increasing `trainer.nu
 
 ## Register the Triton runtime
 
-If the cluster does not already provide a compatible Triton runtime, a cluster administrator can apply [`triton-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml). Before applying it, replace its image with an approved internal mirror pinned by digest:
+If the namespace does not already provide a compatible Triton runtime, download [`triton-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/triton-servingruntime.yaml). Replace its namespace and image with the deployment namespace and an approved internal mirror pinned by digest, then apply it:
 
 ```bash
 kubectl apply -f triton-servingruntime.yaml
@@ -244,7 +248,7 @@ FROM ${BASE_IMAGE}
 
 USER 0
 ARG CANN_PYTHON_SITE_PACKAGES=/usr/local/Ascend/cann-9.0.1/python/site-packages
-RUN python3 -m pip install --no-cache-dir awscli==1.46.0 && \
+RUN python3 -m pip install --no-cache-dir boto3==1.42.97 && \
     python3 -m pip install --no-cache-dir --target "${CANN_PYTHON_SITE_PACKAGES}" \
       numpy==1.26.4 \
       decorator==5.2.1 \
@@ -253,6 +257,9 @@ RUN python3 -m pip install --no-cache-dir awscli==1.46.0 && \
       scipy==1.13.1 \
       attrs==24.2.0 \
       psutil==6.1.1
+
+COPY yolov5_s3_transfer.py /usr/local/bin/yolov5_s3_transfer.py
+RUN chmod 0555 /usr/local/bin/yolov5_s3_transfer.py
 
 # NumPy and SciPy wheels carry native libraries outside their Python packages.
 ENV LD_LIBRARY_PATH=/usr/local/Ascend/cann-9.0.1/python/site-packages/numpy.libs:/usr/local/Ascend/cann-9.0.1/python/site-packages/scipy.libs:${LD_LIBRARY_PATH}
@@ -265,7 +272,7 @@ nerdctl build --platform linux/arm64 -t <your-registry>/yolov5-cann-compiler:9.0
 nerdctl push <your-registry>/yolov5-cann-compiler:9.0.1-910b
 ```
 
-Build for the target `linux/arm64` platform so that the NumPy, SciPy, and psutil wheels match the NPU node architecture. The compiler image needs package access only while it is built. In a restricted network, put the matching CPython 3.11 arm64 wheels in the build context and install them with `--no-index --find-links=<wheelhouse>`; do not give the serving workload broad outbound access merely to install dependencies at startup. Source `/usr/local/Ascend/ascend-toolkit/set_env.sh` before invoking `atc` or importing `acl`.
+Save `yolov5_s3_transfer.py` beside this compiler `Containerfile` before building it. Build for the target `linux/arm64` platform so that the NumPy, SciPy, and psutil wheels match the NPU node architecture. The compiler image needs package access only while it is built. In a restricted network, put the matching CPython 3.11 arm64 wheels in the build context and install them with `--no-index --find-links=<wheelhouse>`; do not give the serving workload broad outbound access merely to install dependencies at startup. Source `/usr/local/Ascend/ascend-toolkit/set_env.sh` before invoking `atc` or importing `acl`.
 
 ### Deploy a compiled `.om` model with AscendCL
 
@@ -285,7 +292,7 @@ Start a container from the compiler image built above. Download `model.onnx` fro
 
 ```bash
 source /usr/local/Ascend/ascend-toolkit/set_env.sh
-aws --endpoint-url "$AWS_S3_ENDPOINT" s3 cp \
+python3 /usr/local/bin/yolov5_s3_transfer.py copy \
   s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-onnx/model.onnx \
   /work/model.onnx
 atc \
@@ -295,12 +302,12 @@ atc \
   --input_format=NCHW \
   --input_shape="images:1,3,640,640" \
   --soc_version=Ascend910B3
-aws --endpoint-url "$AWS_S3_ENDPOINT" s3 cp \
+python3 /usr/local/bin/yolov5_s3_transfer.py copy \
   /work/model.om \
   s3://<bucket>/models/yolov5-coco128/finetune-coco128-v1-ascend910b3-cann9.0.1/1/model.om
 ```
 
-`atc` writes `/work/model.om`. The commands assume an S3-compatible client configured with the same endpoint and least-privilege credentials used by the training workflow. The output prefix must be new and contain only `1/model.om`. Do not use the sample `Ascend910B3` value for a different SKU.
+`atc` writes `/work/model.om`. The `boto3` helper reads the same endpoint and least-privilege credentials used by the training workflow. The output prefix must be new and contain only `1/model.om`. Do not use the sample `Ascend910B3` value for a different SKU.
 
 #### Build the AscendCL serving image
 
@@ -318,7 +325,7 @@ The server initializes AscendCL once, loads `/mnt/models/1/model.om`, validates 
 
 #### Register the AscendCL runtime and deploy the service
 
-Download [`yolov5-ascendcl-om-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml), replace its image with the image you pushed, and apply it as a cluster administrator:
+Download [`yolov5-ascendcl-om-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascendcl-om-servingruntime.yaml), set its namespace to the `InferenceService` namespace, replace its image with the image you pushed, and apply it:
 
 ```bash
 kubectl apply -f yolov5-ascendcl-om-servingruntime.yaml
@@ -376,7 +383,7 @@ nerdctl push <your-registry>/yolov5-ascend:cann8.5
 
 #### Register the Ascend serving runtime
 
-Download [`yolov5-ascend-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml), replace its image with the one you built, and apply it as a cluster administrator:
+Download [`yolov5-ascend-servingruntime.yaml`](https://github.com/alauda/aml-docs/blob/master/docs/en/train/guides/assets/yolov5/yolov5-ascend-servingruntime.yaml), set its namespace to the `InferenceService` namespace, replace its image with the one you built, and apply it:
 
 ```bash
 kubectl apply -f yolov5-ascend-servingruntime.yaml


### PR DESCRIPTION
## Summary
- add a KServe v2 AscendCL serving sample for static FP32 YOLOv5 `.om` models
- use namespace-scoped `ServingRuntime` samples for Triton, `torch_npu`, and AscendCL deployments
- use a bundled `boto3` transfer helper for training inputs/outputs and ONNX-to-`.om` artifact transfer; no AWS CLI is required
- document ONNX export, ATC conversion, isolated S3 artifact storage, and `InferenceService` deployment

## Validation
- `npm run lint`
- `npm run build`
- Python compilation, a stubbed AscendCL lifecycle/input-validation test, and a stubbed `boto3` transfer safety test
- YAML parsing and Trivy misconfiguration/secret scans for the new manifests and Containerfile

The `.om` sample is intentionally fixed to YOLOv5 FP32 input `[1,3,640,640]`. Real-device execution should be validated against the target Ascend SKU and CANN/driver stack.