### PR TITLE
docs: add Kale workspace guide and examples

### DIFF
--- a/docs/en/develop/workbench/kale.mdx
+++ b/docs/en/develop/workbench/kale.mdx
@@ -1,0 +1,152 @@
+---
+weight: 30
+---
+
+# Run Kubeflow Pipelines from a Kale Workbench
+
+Kale is a JupyterLab extension that turns annotated notebook cells into a Kubeflow
+Pipelines (KFP) v2 pipeline. Use a JupyterLab WorkspaceKind built with the Kale
+extension; do not install Kale interactively into a running workbench because the
+extension and its server component must use matching versions.
+
+## Prerequisites
+
+- Kubeflow Pipelines is installed and its `ml-pipeline` service is available in the
+  `kubeflow` namespace.
+- The workbench namespace is managed by a Kubeflow `Profile`. This gives the
+  namespace the `kubeflow-profile` label required by the Pipeline API NetworkPolicy.
+- The WorkspaceKind uses a service account that can request the projected token for
+  the `pipelines.kubeflow.org` audience.
+- A Kale JupyterLab image has been built and published to an image registry that
+  cluster nodes can pull from. Ask your platform administrator for the image address
+  and tag.
+
+## Configure Kale authentication per namespace
+
+Kale reads KFP authentication from `kfp_server_config.json`. Store only a token
+*path* in the ConfigMap: the token itself stays in the projected service-account
+volume and is refreshed by Kubernetes.
+
+Create this ConfigMap in every namespace that will use the Kale WorkspaceKind.
+Replace `<your-namespace>` with the namespace of the workbench.
+
+```yaml title=kale-kfp-server-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kale-kfp-server-config
+  namespace: <your-namespace>
+data:
+  kfp_server_config.json: |
+    {
+      "host": "http://ml-pipeline.kubeflow.svc.cluster.local:8888",
+      "auth_type": "kubernetes_service_account_token",
+      "auth_config": {
+        "token_path": "/var/run/secrets/kubeflow/pipelines/token"
+      },
+      "namespace": "<your-namespace>"
+    }
+```
+
+Apply it with:
+
+```bash
+kubectl apply -f kale-kfp-server-config.yaml
+```
+
+## Create a Kale WorkspaceKind
+
+The following excerpt shows the Kale-specific parts of a JupyterLab
+`WorkspaceKind`. Add the usual resource options, probes, and workbench labels used
+by your platform. The `NB_PREFIX` and `NOTEBOOK_BASE_URL` values must match the
+Skipper route for the target cluster.
+
+```yaml title=kale-jupyterlab-workspacekind.yaml
+apiVersion: kubeflow.org/v1beta1
+kind: WorkspaceKind
+metadata:
+  name: kale-jupyterlab
+spec:
+  podTemplate:
+    extraEnv:
+      - name: NB_PREFIX
+        value: /clusters/<cluster>/aml/aml-workbench{{ httpPathPrefix "jupyterlab" }}
+      - name: NOTEBOOK_BASE_URL
+        value: /clusters/<cluster>/aml/aml-workbench{{ httpPathPrefix "jupyterlab" }}
+      - name: NOTEBOOK_ARGS
+        value: --ServerApp.token='' --ServerApp.password=''
+      - name: KF_PIPELINES_ENDPOINT
+        value: http://ml-pipeline.kubeflow.svc.cluster.local:8888
+      - name: KALE_CONFIG_PATH
+        value: /etc/kale/kfp_server_config.json
+    extraVolumes:
+      - name: kfp-api-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                audience: pipelines.kubeflow.org
+                expirationSeconds: 3607
+                path: token
+      - name: kale-kfp-server-config
+        configMap:
+          name: kale-kfp-server-config
+    extraVolumeMounts:
+      - name: kfp-api-token
+        mountPath: /var/run/secrets/kubeflow/pipelines
+        readOnly: true
+      - name: kale-kfp-server-config
+        mountPath: /etc/kale
+        readOnly: true
+    options:
+      imageConfig:
+        spawner:
+          default: kale-jupyterlab
+        values:
+          - id: kale-jupyterlab
+            spawner:
+              displayName: JupyterLab | Kale | CPU
+              description: JupyterLab with the Kubeflow Kale extension.
+            spec:
+              image: <registry>/<project>/kale-jupyterlab:<tag>
+              imagePullPolicy: IfNotPresent
+              ports:
+                - id: jupyterlab
+                  displayName: JupyterLab
+                  port: 8888
+                  protocol: HTTP
+    serviceAccount:
+      name: aml-editor
+```
+
+The ConfigMap is namespace-scoped. A WorkspaceKind can be cluster-scoped, but each
+namespace using it must contain its own `kale-kfp-server-config` ConfigMap with the
+matching KFP namespace value.
+
+Apply the WorkspaceKind and create a workbench from it:
+
+```bash
+kubectl apply -f kale-jupyterlab-workspacekind.yaml
+```
+
+## Use Kale in JupyterLab
+
+1. Open the running Kale workbench and upload a notebook.
+2. Open the Kale panel from the left sidebar.
+3. Mark cells as pipeline steps and set the pipeline and experiment names.
+4. Select **Compile and Run**. Kale compiles the notebook, uploads it to KFP, and
+   starts a run in the namespace configured in `kfp_server_config.json`.
+
+If Kale reports an empty identity or `401 Unauthorized`, verify that
+`KALE_CONFIG_PATH` points to the mounted ConfigMap and that the Pipeline token is
+mounted at `/var/run/secrets/kubeflow/pipelines/token`. A reachable Pipeline health
+endpoint alone is not sufficient: Kale must use that projected token to authenticate.
+
+## Examples
+
+- [Download the Iris scikit-learn pipeline notebook](/kale/iris-sklearn.ipynb).
+  It is a compact end-to-end example for testing compilation and KFP submission;
+  its [requirements file](/kale/iris-sklearn-requirements.txt) is included.
+- [Download the candies-sharing notebook](/kale/candies-sharing.ipynb). It is a
+  minimal example for learning cell annotations before using a larger notebook.
+
+The examples are copied from the upstream [Kubeflow Kale repository](https://github.com/kubeflow/kale).

--- a/docs/public/kale/candies-sharing.ipynb
+++ b/docs/public/kale/candies-sharing.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Kale base example\n",
+    "\n",
+    "This notebook presents a minimal example to show how Kale can convert a Notebook to a pipeline applying Notebook annotations.\n",
+    "\n",
+    "Variables that are constant throughout the Notebook are transformed into pipeline parameters, so that the pipeline can be re-run with different initializations. Code cells are divided into pipeline steps by mean of notebook tags. You can look at the annotations by inspecting the Notebook source, or by installing the Kale jupyter extension (see [github.com/kubeflow-kale/kale](https://github.com/kubeflow-kale/kale))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "imports"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import random"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "pipeline-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "CANDIES = 20"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "functions"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def get_handful(left):\n",
+    "    if left == 0:\n",
+    "        print(\"There are no candies left! I want to cry :(\")\n",
+    "        return 0\n",
+    "    c = random.randint(1, left)\n",
+    "    print(\"I got %s candies!\" % c)\n",
+    "    return c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "step:sack"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Let's put in a bag 20 candies and have three kids get a handful of them each\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Let's put in a bag %s candies and have three kids get a handful of them each\" % CANDIES)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "prev:sack",
+     "step:kid1"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I got 4 candies!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# kid1 gets a handful, without looking in the bag!\n",
+    "kid1 = get_handful(CANDIES)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "prev:kid1",
+     "step:kid2"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I got 3 candies!\n"
+     ]
+    }
+   ],
+   "source": [
+    "kid2 = get_handful(CANDIES - kid1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "prev:kid2",
+     "step:kid3",
+     "prev:kid1"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I got 2 candies!\n"
+     ]
+    }
+   ],
+   "source": [
+    "kid3 = get_handful(CANDIES - kid1 - kid2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": [
+     "pipeline-metrics"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4\n",
+      "3\n",
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(kid1)\n",
+    "print(kid2)\n",
+    "print(kid3)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "kubeflow_notebook": {
+   "base_image": "",
+   "experiment": {
+    "id": "",
+    "name": ""
+   },
+   "experiment_name": "",
+   "pipeline_description": "Share some candies between three lovely kids",
+   "pipeline_name": "candies-sharing",
+   "volumes": []
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/public/kale/iris-sklearn-requirements.txt
+++ b/docs/public/kale/iris-sklearn-requirements.txt
@@ -1,0 +1,2 @@
+joblib
+scikit-learn>=1.3.0

--- a/docs/public/kale/iris-sklearn.ipynb
+++ b/docs/public/kale/iris-sklearn.ipynb
@@ -1,0 +1,408 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Install necessary packages\n",
+    "\n",
+    "We can install the necessary packages by either running `pip install --user <package_name>` or include everything in a `requirements.txt` file and run `pip install --user -r requirements.txt`.\n",
+    "\n",
+    "> NOTE: Do not forget to use the `--user` argument. It is necessary if you want to use Kale to transform this notebook into a Kubeflow pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!pip3 install --user -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Imports\n",
+    "\n",
+    "In this section we import the packages we need for this example. Make it a habbit to gather your imports in a single place. It will make your life easier if you are going to transform this notebook into a Kubeflow pipeline using Kale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "imports"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import sklearn\n",
+    "import numpy as np\n",
+    "\n",
+    "from sklearn import datasets\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.metrics import precision_score, recall_score, f1_score, accuracy_score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Project hyper-parameters\n",
+    "\n",
+    "In this cell, we define the different hyper-parameters variables. Defining them in one place makes it easier to experiment with their values and also facilitates the execution of HP Tuning experiments using Kale and Katib."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "pipeline-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "N_ESTIMATORS = 500\n",
+    "MAX_DEPTH = 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Load and preprocess data\n",
+    "\n",
+    "In this section, we load and process the dataset to get it in a ready-to-use form by the model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "step:load_transform_data",
+     "report:disabled"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x, y = datasets.load_iris(return_X_y=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "x_trn, x_tst, y_trn, y_tst = train_test_split(x, y, test_size=.2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Define and train the model\n",
+    "\n",
+    "We are now ready to define our model. In this example, we use the scikit-learn implementation of Random Forest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "prev:load_transform_data",
+     "step:train_model"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "model = RandomForestClassifier(n_estimators=int(N_ESTIMATORS),\n",
+    "                               max_depth=int(MAX_DEPTH))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model.fit(x_trn, y_trn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Evaluate the model\n",
+    "\n",
+    "Finally, we are ready to evaluate the model using the test set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "step:evaluate_model",
+     "prev:load_transform_data",
+     "prev:train_model",
+     "report:disabled"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "preds = model.predict(x_tst)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "precision = precision_score(y_tst, preds, average='macro')\n",
+    "recall = recall_score(y_tst, preds, average='macro')\n",
+    "f1 = f1_score(y_tst, preds, average='macro')\n",
+    "accuracy = accuracy_score(y_tst, preds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Pipeline metrics\n",
+    "\n",
+    "In the last cell of the Notebook, we print the pipeline metrics. These will be picked up by Kubeflow Pipelines, which will make them available through its UI."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "pipeline-metrics"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(precision)\n",
+    "print(recall)\n",
+    "print(f1)\n",
+    "print(accuracy)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "kubeflow_notebook": {
+   "enable_caching": false,
+   "experiment": {
+    "id": "new",
+    "name": "iris-experiment"
+   },
+   "experiment_name": "iris-experiment",
+   "katib_metadata": {
+    "algorithm": {
+     "algorithmName": "grid",
+     "algorithmSettings": [
+      {
+       "name": "random_state",
+       "value": "10"
+      },
+      {
+       "name": "acq_optimizer",
+       "value": "auto"
+      },
+      {
+       "name": "acq_func",
+       "value": "gp_hedge"
+      },
+      {
+       "name": "base_estimator",
+       "value": "GP"
+      }
+     ]
+    },
+    "maxFailedTrialCount": 3,
+    "maxTrialCount": 15,
+    "objective": {
+     "additionalMetricNames": [
+      "precision",
+      "recall",
+      "f1"
+     ],
+     "goal": 1,
+     "objectiveMetricName": "accuracy",
+     "type": "maximize"
+    },
+    "parallelTrialCount": 3,
+    "parameters": [
+     {
+      "feasibleSpace": {
+       "max": "0.3",
+       "min": "0.1",
+       "step": "0.1"
+      },
+      "name": "ETA",
+      "parameterType": "double"
+     },
+     {
+      "feasibleSpace": {
+       "max": "6",
+       "min": "2",
+       "step": "1"
+      },
+      "name": "MAX_DEPTH",
+      "parameterType": "int"
+     },
+     {
+      "feasibleSpace": {
+       "list": [
+        "multi:softprob",
+        "multi:softmax"
+       ]
+      },
+      "name": "OBJECTIVE",
+      "parameterType": "categorical"
+     },
+     {
+      "feasibleSpace": {
+       "max": "100",
+       "min": "20",
+       "step": "10"
+      },
+      "name": "STEPS",
+      "parameterType": "int"
+     }
+    ]
+   },
+   "katib_run": false,
+   "pipeline_description": "Train a Random Forest classifier on the Iris dataset",
+   "pipeline_name": "iris-pipeline",
+   "snapshot_volumes": true,
+   "steps_defaults": [
+    "label:access-ml-pipeline:true"
+   ],
+   "volumes": [
+    {
+     "annotations": [],
+     "mount_point": "/home/jovyan",
+     "name": "workspace-examples-serving-bgsd4h5em",
+     "size": 5,
+     "size_type": "Gi",
+     "snapshot": false,
+     "type": "clone"
+    },
+    {
+     "annotations": [],
+     "mount_point": "/home/jovyan/data",
+     "name": "data-8lbdjmzdh",
+     "size": 10,
+     "size_type": "Gi",
+     "snapshot": false,
+     "type": "clone"
+    }
+   ]
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  },
+  "nteract": {
+   "version": "0.25.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Adds a Kale JupyterLab Workspace guide covering Profile-backed namespace access, KFP service-account authentication, and WorkspaceKind configuration. Includes the upstream Iris and candies-sharing notebook examples.